### PR TITLE
fix: report proof construction errors instead of swallowing silently

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,7 @@ export interface X402Config {
   nightmareConfirmation?: string
   onLimitReached?: (reason: string) => void
   onYellowLight?: (detail: YellowLightEvent) => Promise<boolean>
+  onProofError?: (error: unknown, protocol: PaymentProtocol) => void
   now?: () => number
 }
 

--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -607,4 +607,40 @@ describe("createX402Fetch — BRC-105", () => {
     expect(res.status).toBe(402)
     expect(failingProof).toHaveBeenCalledOnce()
   })
+
+  it("calls onProofError callback when proof construction fails", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeBrc105Response(1000))
+
+    const error = new Error("Wallet locked")
+    const onProofError = vi.fn()
+    const f = createX402Fetch({
+      tier: "I'm Too Young to Die",
+      storage: mockStorage(),
+      now: () => NOW,
+      brc105ProofConstructor: vi.fn().mockRejectedValue(error),
+      onProofError,
+    })
+
+    const res = await f("https://api.example.com/data")
+    expect(res.status).toBe(402)
+    expect(onProofError).toHaveBeenCalledOnce()
+    expect(onProofError).toHaveBeenCalledWith(error, "brc105")
+  })
+
+  it("logs proof construction error to console", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeBrc105Response(1000))
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const f = createX402Fetch({
+      tier: "I'm Too Young to Die",
+      storage: mockStorage(),
+      now: () => NOW,
+      brc105ProofConstructor: vi.fn().mockRejectedValue(new Error("No funds")),
+    })
+
+    await f("https://api.example.com/data")
+    expect(consoleSpy).toHaveBeenCalledOnce()
+    expect(consoleSpy.mock.calls[0][0]).toContain("brc105")
+    consoleSpy.mockRestore()
+  })
 })

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -256,8 +256,9 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
       let proof: P
       try {
         proof = await buildProof()
-      } catch {
-        // Proof construction failed — return original 402
+      } catch (err) {
+        console.error(`[x402] Proof construction failed (${protocol}):`, err)
+        config.onProofError?.(err, protocol)
         return originalResponse
       }
 


### PR DESCRIPTION
## Summary

- `console.error` with protocol name when proof construction fails
- New `onProofError(error, protocol)` callback on `X402Config` — lets callers surface meaningful messages (e.g. "Wallet locked") instead of a generic 402
- Still returns original 402 response (non-breaking)

## Test plan

- [x] All 206 tests pass (2 new)
- [x] `onProofError` called with error and protocol name
- [x] `console.error` logged with protocol identifier

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)