### PR TITLE
feat: display wallet receive address in extension popup

### DIFF
--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -6,11 +6,70 @@ import * as wallet from './wallet-controller'
 import * as x402 from './x402-controller'
 
 // ---------------------------------------------------------------------------
+// Pubkey → P2PKH address (for popup display)
+// ---------------------------------------------------------------------------
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16)
+  }
+  return bytes
+}
+
+async function hash160(data: Uint8Array): Promise<Uint8Array> {
+  // Import ripemd160 inline to avoid circular deps — same impl as brc105-proof.ts
+  const { ripemd160 } = await import('../../src/brc105-proof')
+  const sha256 = new Uint8Array(await crypto.subtle.digest('SHA-256', data))
+  return ripemd160(sha256)
+}
+
+async function pubkeyToAddress(pubkeyHex: string): Promise<string> {
+  const pubkeyBytes = hexToBytes(pubkeyHex)
+  const pubkeyHash = await hash160(pubkeyBytes)
+
+  // Version byte (0x00 for mainnet) + 20-byte hash
+  const payload = new Uint8Array(21)
+  payload[0] = 0x00
+  payload.set(pubkeyHash, 1)
+
+  // Double-SHA256 checksum (first 4 bytes)
+  const hash1 = new Uint8Array(await crypto.subtle.digest('SHA-256', payload))
+  const hash2 = new Uint8Array(await crypto.subtle.digest('SHA-256', hash1))
+  const checksum = hash2.slice(0, 4)
+
+  // Concatenate payload + checksum
+  const addressBytes = new Uint8Array(25)
+  addressBytes.set(payload)
+  addressBytes.set(checksum, 21)
+
+  // Base58 encode
+  let num = 0n
+  for (const b of addressBytes) num = num * 256n + BigInt(b)
+
+  let encoded = ''
+  while (num > 0n) {
+    encoded = BASE58_ALPHABET[Number(num % 58n)] + encoded
+    num = num / 58n
+  }
+
+  // Preserve leading zero bytes as '1's
+  for (const b of addressBytes) {
+    if (b !== 0) break
+    encoded = '1' + encoded
+  }
+
+  return encoded
+}
+
+// ---------------------------------------------------------------------------
 // Message type guards
 // ---------------------------------------------------------------------------
 
 interface InternalMessage {
-  type: 'unlock' | 'lock' | 'setup' | 'getState' | 'setNetwork' | 'setTier' | 'switchBackend' | 'getSpendStatus' | 'openPopupTab'
+  type: 'unlock' | 'lock' | 'setup' | 'getState' | 'getAddress' | 'setNetwork' | 'setTier' | 'switchBackend' | 'getSpendStatus' | 'openPopupTab'
   payload?: unknown
 }
 
@@ -60,6 +119,16 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
 
     case 'getState':
       break // just return composed state below
+
+    case 'getAddress': {
+      if (!wallet.isUnlocked()) throw new Error('Wallet is locked')
+      const backend = wallet.getBackend()
+      const result = await backend.call('getPublicKey', { identityKey: true }, 'self') as { publicKey: string }
+      const address = await pubkeyToAddress(result.publicKey)
+      const walletState = await wallet.getWalletState()
+      const x402State = x402.getX402State()
+      return { ...walletState, ...x402State, address }
+    }
 
     case 'switchBackend': {
       const payload = message.payload as { type: 'builtin' | 'external'; extensionId?: string } | undefined

--- a/plugins/shared/ui/popup.css
+++ b/plugins/shared/ui/popup.css
@@ -119,6 +119,35 @@ label {
 }
 .setup-btn:hover { opacity: 0.85; }
 
+.address-section { margin-bottom: 14px; }
+.address-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #16213e;
+  border-radius: 6px;
+  padding: 6px 8px;
+}
+.address-text {
+  flex: 1;
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  color: #ccc;
+  word-break: break-all;
+  user-select: all;
+}
+.copy-btn {
+  background: #2a2a4a;
+  border: none;
+  color: #e0e0e0;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  white-space: nowrap;
+}
+.copy-btn:hover { background: #00d4aa; color: #1a1a2e; }
+
 .unlock-form { margin-bottom: 8px; }
 .unlock-input {
   width: 100%;

--- a/plugins/shared/ui/popup.html
+++ b/plugins/shared/ui/popup.html
@@ -24,6 +24,14 @@
         <span id="balance-display">--- sats</span>
       </section>
 
+      <section id="address-section" class="address-section" hidden>
+        <label>Receive Address</label>
+        <div class="address-row">
+          <span id="address-display" class="address-text"></span>
+          <button id="copy-address-btn" class="copy-btn" title="Copy address">Copy</button>
+        </div>
+      </section>
+
       <div class="actions">
         <div id="unlock-form" class="unlock-form" hidden>
           <input type="password" id="unlock-password" class="unlock-input" placeholder="Enter password" autocomplete="current-password">

--- a/plugins/shared/ui/popup.ts
+++ b/plugins/shared/ui/popup.ts
@@ -59,6 +59,12 @@ function updateWalletPanel(state: PopupState): void {
 
   balanceEl.textContent =
     state.balance !== undefined ? `${state.balance.toLocaleString()} sats` : "--- sats";
+
+  // Show/hide address section based on unlock state
+  const addressSection = document.getElementById("address-section") as HTMLDivElement | null;
+  if (addressSection) {
+    addressSection.hidden = !state.isUnlocked;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -124,6 +130,20 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   }
 
+  // Fetch and display wallet address when unlocked
+  async function fetchAddress(): Promise<void> {
+    const addressDisplay = document.getElementById("address-display");
+    if (!addressDisplay) return;
+    try {
+      const result = await sendMessage({ type: "getAddress" }) as PopupState & { address?: string };
+      if (result.address) {
+        addressDisplay.textContent = result.address;
+      }
+    } catch {
+      addressDisplay.textContent = "";
+    }
+  }
+
   // Fetch initial state
   function updateUI(state: PopupState): void {
     updateWalletPanel(state);
@@ -133,6 +153,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     const state = await sendMessage({ type: "getState" });
     updateUI(state);
+    if (state.isUnlocked) fetchAddress();
   } catch {
     updateUI({
       isSetUp: false,
@@ -181,6 +202,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             unlockForm.hidden = true;
             unlockPassword.value = "";
             updateUI(state);
+            fetchAddress();
           } catch (err) {
             if (unlockError) unlockError.textContent = err instanceof Error ? err.message : String(err);
           } finally {
@@ -226,6 +248,31 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (setupBtn) {
     setupBtn.addEventListener("click", () => {
       chrome.tabs.create({ url: chrome.runtime.getURL("ui/wallet/setup.html") });
+    });
+  }
+
+  // Wallet: Copy address
+  const copyAddressBtn = document.getElementById("copy-address-btn");
+  if (copyAddressBtn) {
+    copyAddressBtn.addEventListener("click", async () => {
+      const addressDisplay = document.getElementById("address-display");
+      const text = addressDisplay?.textContent ?? "";
+      if (!text) return;
+      try {
+        await navigator.clipboard.writeText(text);
+        copyAddressBtn.textContent = "Copied!";
+        setTimeout(() => { copyAddressBtn.textContent = "Copy"; }, 1500);
+      } catch {
+        // Fallback for environments where clipboard API is unavailable
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+        copyAddressBtn.textContent = "Copied!";
+        setTimeout(() => { copyAddressBtn.textContent = "Copy"; }, 1500);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

- Popup shows the wallet's P2PKH receive address when unlocked
- Address derived from identity key via hash160 + base58check encoding
- Copy button with clipboard API + fallback
- Address section hidden when wallet is locked

## Test plan

- [x] All 206 tests pass
- [x] Chromium plugin builds cleanly
- [ ] Manual: unlock wallet → address appears with copy button
- [ ] Manual: lock wallet → address section hides
- [ ] Manual: copy button copies correct address

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)