### PR TITLE
feat: scan for legacy P2PKH UTXOs on wallet unlock

### DIFF
--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -2,6 +2,7 @@
 
 import type { ContentToBackgroundMessage, CWIResponse } from './messages'
 import { handleCWIRequest } from './cwi-proxy'
+import { BuiltInWalletBackend } from './builtin-wallet-backend'
 import * as wallet from './wallet-controller'
 import * as x402 from './x402-controller'
 
@@ -65,6 +66,73 @@ async function pubkeyToAddress(pubkeyHex: string): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
+// Scan for legacy P2PKH UTXOs at the identity key address
+// ---------------------------------------------------------------------------
+
+async function scanAndImportUtxos(): Promise<void> {
+  const rootKeyHex = wallet.getRootKeyHex()
+  if (!rootKeyHex) return
+
+  const backend = wallet.getBackend()
+  const { publicKey: identityKeyHex } = await backend.call('getPublicKey', { identityKey: true }, 'self') as { publicKey: string }
+  const address = await pubkeyToAddress(identityKeyHex)
+
+  // Look up UTXOs at the identity key's P2PKH address
+  const utxos = await fetchUtxos(address)
+  if (utxos.length === 0) {
+    console.log('x402: no legacy UTXOs found at identity address')
+    return
+  }
+
+  console.log(`x402: found ${utxos.length} UTXO(s) at identity address, importing...`)
+
+  // Build outpoints and KeyPairAddress for fundWalletFromP2PKHOutpoints
+  const outpoints = utxos.map((u) => `${u.tx_hash}.${u.tx_pos}`)
+  const { PrivateKey } = await import('@bsv/sdk')
+  const privateKey = PrivateKey.fromHex(rootKeyHex)
+  const publicKey = privateKey.toPublicKey()
+  const p2pkhKey = { privateKey, publicKey, address }
+
+  const { SetupClient } = await import('@bsv/wallet-toolbox-client')
+  if (!(backend instanceof BuiltInWalletBackend)) return
+  const walletInterface = backend.getWalletInterface()
+  if (!walletInterface) {
+    console.warn('x402: wallet instance not available for UTXO import')
+    return
+  }
+
+  const results = await SetupClient.fundWalletFromP2PKHOutpoints(walletInterface, outpoints, p2pkhKey)
+  for (const r of results) {
+    if (r.success) {
+      console.log(`x402: imported UTXO ${r.outpoint} → ${r.txid}`)
+    } else {
+      console.warn(`x402: failed to import UTXO ${r.outpoint}: ${r.error}`)
+    }
+  }
+}
+
+async function fetchUtxos(address: string): Promise<Array<{ tx_hash: string; tx_pos: number; value: number }>> {
+  const providers = [
+    `https://api.whatsonchain.com/v1/bsv/main/address/${address}/unspent`,
+  ]
+  for (const url of providers) {
+    try {
+      const ctrl = new AbortController()
+      const t = setTimeout(() => ctrl.abort(), 8000)
+      const res = await fetch(url, { signal: ctrl.signal })
+      clearTimeout(t)
+      if (res.ok) {
+        const data = await res.json()
+        if (Array.isArray(data)) return data
+      }
+    } catch {
+      // Try next provider
+    }
+  }
+  return []
+}
+
+// ---------------------------------------------------------------------------
 // Message type guards
 // ---------------------------------------------------------------------------
 
@@ -92,6 +160,10 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
       const payload = message.payload as { password: string } | undefined
       if (!payload?.password) throw new Error('Password required')
       await wallet.unlock(payload.password)
+      // Scan for legacy P2PKH UTXOs in the background (don't block unlock)
+      scanAndImportUtxos().catch((err) => {
+        console.warn('x402: UTXO scan failed (non-blocking):', err)
+      })
       break
     }
     case 'lock':
@@ -127,7 +199,7 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
       const address = await pubkeyToAddress(result.publicKey)
       const walletState = await wallet.getWalletState()
       const x402State = x402.getX402State()
-      return { ...walletState, ...x402State, address }
+      return { ...walletState, ...x402State, identityKey: result.publicKey, address }
     }
 
     case 'switchBackend': {

--- a/plugins/shared/builtin-wallet-backend.ts
+++ b/plugins/shared/builtin-wallet-backend.ts
@@ -89,4 +89,9 @@ export class BuiltInWalletBackend implements WalletBackend {
   hasOwnUI(): boolean {
     return false
   }
+
+  /** Get the underlying WalletInterface (for fundWalletFromP2PKHOutpoints). */
+  getWalletInterface(): WalletInterface | null {
+    return this.wallet
+  }
 }

--- a/plugins/shared/ui/popup.html
+++ b/plugins/shared/ui/popup.html
@@ -32,6 +32,14 @@
         </div>
       </section>
 
+      <section id="identity-section" class="address-section" hidden>
+        <label>Identity Key</label>
+        <div class="address-row">
+          <span id="identity-display" class="address-text"></span>
+          <button id="copy-identity-btn" class="copy-btn" title="Copy identity key">Copy</button>
+        </div>
+      </section>
+
       <div class="actions">
         <div id="unlock-form" class="unlock-form" hidden>
           <input type="password" id="unlock-password" class="unlock-input" placeholder="Enter password" autocomplete="current-password">

--- a/plugins/shared/ui/popup.ts
+++ b/plugins/shared/ui/popup.ts
@@ -23,6 +23,22 @@ interface PopupState {
 const $ = <T extends HTMLElement>(id: string): T =>
   document.getElementById(id) as T;
 
+async function copyToClipboard(text: string, btn: HTMLElement): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+  }
+  const original = btn.textContent;
+  btn.textContent = "Copied!";
+  setTimeout(() => { btn.textContent = original; }, 1500);
+}
+
 // ---------------------------------------------------------------------------
 // Wallet panel UI (only when built-in backend is active)
 // ---------------------------------------------------------------------------
@@ -60,11 +76,11 @@ function updateWalletPanel(state: PopupState): void {
   balanceEl.textContent =
     state.balance !== undefined ? `${state.balance.toLocaleString()} sats` : "--- sats";
 
-  // Show/hide address section based on unlock state
+  // Show/hide address and identity sections based on unlock state
   const addressSection = document.getElementById("address-section") as HTMLDivElement | null;
-  if (addressSection) {
-    addressSection.hidden = !state.isUnlocked;
-  }
+  const identitySection = document.getElementById("identity-section") as HTMLDivElement | null;
+  if (addressSection) addressSection.hidden = !state.isUnlocked;
+  if (identitySection) identitySection.hidden = !state.isUnlocked;
 }
 
 // ---------------------------------------------------------------------------
@@ -130,17 +146,23 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   }
 
-  // Fetch and display wallet address when unlocked
-  async function fetchAddress(): Promise<void> {
+  // Fetch and display wallet identity key + address when unlocked
+  async function fetchWalletInfo(): Promise<void> {
     const addressDisplay = document.getElementById("address-display");
-    if (!addressDisplay) return;
+    const identityDisplay = document.getElementById("identity-display");
+    const identitySection = document.getElementById("identity-section");
     try {
-      const result = await sendMessage({ type: "getAddress" }) as PopupState & { address?: string };
-      if (result.address) {
+      const result = await sendMessage({ type: "getAddress" }) as PopupState & { identityKey?: string; address?: string };
+      if (identityDisplay && result.identityKey) {
+        identityDisplay.textContent = result.identityKey;
+        if (identitySection) identitySection.hidden = false;
+      }
+      if (addressDisplay && result.address) {
         addressDisplay.textContent = result.address;
       }
     } catch {
-      addressDisplay.textContent = "";
+      if (addressDisplay) addressDisplay.textContent = "";
+      if (identityDisplay) identityDisplay.textContent = "";
     }
   }
 
@@ -153,7 +175,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     const state = await sendMessage({ type: "getState" });
     updateUI(state);
-    if (state.isUnlocked) fetchAddress();
+    if (state.isUnlocked) fetchWalletInfo();
   } catch {
     updateUI({
       isSetUp: false,
@@ -202,7 +224,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             unlockForm.hidden = true;
             unlockPassword.value = "";
             updateUI(state);
-            fetchAddress();
+            fetchWalletInfo();
           } catch (err) {
             if (unlockError) unlockError.textContent = err instanceof Error ? err.message : String(err);
           } finally {
@@ -251,28 +273,23 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
   }
 
+  // Wallet: Copy identity key
+  const copyIdentityBtn = document.getElementById("copy-identity-btn");
+  if (copyIdentityBtn) {
+    copyIdentityBtn.addEventListener("click", async () => {
+      const identityDisplay = document.getElementById("identity-display");
+      const text = identityDisplay?.textContent ?? "";
+      if (!text) return;
+      await copyToClipboard(text, copyIdentityBtn);
+    });
+  }
+
   // Wallet: Copy address
   const copyAddressBtn = document.getElementById("copy-address-btn");
   if (copyAddressBtn) {
     copyAddressBtn.addEventListener("click", async () => {
-      const addressDisplay = document.getElementById("address-display");
-      const text = addressDisplay?.textContent ?? "";
-      if (!text) return;
-      try {
-        await navigator.clipboard.writeText(text);
-        copyAddressBtn.textContent = "Copied!";
-        setTimeout(() => { copyAddressBtn.textContent = "Copy"; }, 1500);
-      } catch {
-        // Fallback for environments where clipboard API is unavailable
-        const textarea = document.createElement("textarea");
-        textarea.value = text;
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textarea);
-        copyAddressBtn.textContent = "Copied!";
-        setTimeout(() => { copyAddressBtn.textContent = "Copy"; }, 1500);
-      }
+      const text = document.getElementById("address-display")?.textContent ?? "";
+      if (text) await copyToClipboard(text, copyAddressBtn);
     });
   }
 

--- a/plugins/shared/wallet-controller.ts
+++ b/plugins/shared/wallet-controller.ts
@@ -21,6 +21,7 @@ const WALLET_KEY_STORAGE = 'x402_wallet_rootkey'
 
 let walletNetwork: 'main' | 'test' = 'main'
 let walletInitialised = false
+let rootKeyHexInMemory: string | null = null
 
 /** The active wallet backend. Defaults to built-in. */
 let backend: WalletBackend = new BuiltInWalletBackend()
@@ -72,6 +73,7 @@ export async function setup(seed: string, password: string): Promise<void> {
   if (backend instanceof BuiltInWalletBackend) {
     await backend.setup(seed, walletNetwork)
     walletInitialised = true
+    rootKeyHexInMemory = seed
   }
   console.log('x402: wallet set up')
 }
@@ -108,6 +110,7 @@ export async function unlock(password: string): Promise<void> {
   if (backend instanceof BuiltInWalletBackend) {
     await backend.setup(rootKeyHex, walletNetwork)
     walletInitialised = true
+    rootKeyHexInMemory = rootKeyHex
   }
   console.log('x402: wallet unlocked')
 }
@@ -118,8 +121,14 @@ export function lock(): void {
   if (backend instanceof BuiltInWalletBackend) {
     backend = new BuiltInWalletBackend()
     walletInitialised = false
+    rootKeyHexInMemory = null
   }
   console.log('x402: wallet locked')
+}
+
+/** Get the root key hex (only available while unlocked). */
+export function getRootKeyHex(): string | null {
+  return rootKeyHexInMemory
 }
 
 /** Set the network. Only accepts 'main' or 'test'. */


### PR DESCRIPTION
## Summary

- **Scan on unlock** — automatically discovers UTXOs at the identity key's P2PKH address (via WhatsOnChain) and imports them via `fundWalletFromP2PKHOutpoints`. Non-blocking, logs results.
- **Identity key display** — popup now shows the wallet's identity key (pubkey hex) with copy button, alongside the receive address
- **Root key in memory** — retained during unlock session for UTXO import, cleared on lock
- **Refactored copy** — extracted `copyToClipboard` helper, deduplicating clipboard logic

## Test plan

- [x] All 209 tests pass
- [x] Chromium plugin builds cleanly
- [ ] Manual: unlock wallet → console shows UTXO scan results
- [ ] Manual: stranded funds at identity address imported on unlock
- [ ] Manual: identity key displayed in popup with copy button

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)