### PR TITLE
fix: use 'anyone' counterparty in no-auth BRC-105 mode

### DIFF
--- a/src/brc105-challenge.test.ts
+++ b/src/brc105-challenge.test.ts
@@ -19,6 +19,7 @@ describe("parseBrc105Challenge", () => {
     expect(c.satoshisRequired).toBe(5)
     expect(c.serverIdentityKey).toBe("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
     expect(c.derivationPrefix).toBe("AQID")
+    expect(c.authenticated).toBe(true)
   })
 
   it("handles case-insensitive header names", () => {
@@ -84,6 +85,7 @@ describe("parseBrc105Challenge", () => {
       "x-bsv-payment-identity-key": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
     }))
     expect(c.serverIdentityKey).toBe("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+    expect(c.authenticated).toBe(false)
   })
 
   it("falls back to payment header when auth header is empty", () => {
@@ -93,6 +95,7 @@ describe("parseBrc105Challenge", () => {
       "x-bsv-payment-identity-key": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
     }))
     expect(c.serverIdentityKey).toBe("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+    expect(c.authenticated).toBe(false)
   })
 
   it("prefers x-bsv-auth-identity-key when both are present", () => {

--- a/src/brc105-challenge.ts
+++ b/src/brc105-challenge.ts
@@ -34,10 +34,10 @@ export function parseBrc105Challenge(response: Response): Brc105Challenge {
   // Accept identity key from BRC-103 auth layer or standalone BRC-105 header.
   // Treat empty values as absent so the fallback works when auth middleware
   // sends an empty header but the payment header has a valid key.
-  const serverIdentityKey =
-    response.headers.get("x-bsv-auth-identity-key") ||
-    response.headers.get("x-bsv-payment-identity-key") ||
-    null
+  const authIdentityKey = response.headers.get("x-bsv-auth-identity-key") || null
+  const paymentIdentityKey = response.headers.get("x-bsv-payment-identity-key") || null
+  const authenticated = authIdentityKey !== null && authIdentityKey.length > 0
+  const serverIdentityKey = authIdentityKey || paymentIdentityKey
   if (serverIdentityKey === null || serverIdentityKey.length === 0) {
     throw new Error("BRC-105: missing identity key (expected x-bsv-auth-identity-key or x-bsv-payment-identity-key)")
   }
@@ -55,5 +55,6 @@ export function parseBrc105Challenge(response: Response): Brc105Challenge {
     satoshisRequired,
     serverIdentityKey,
     derivationPrefix,
+    authenticated,
   }
 }

--- a/src/brc105-proof.test.ts
+++ b/src/brc105-proof.test.ts
@@ -15,6 +15,7 @@ const CHALLENGE: Brc105Challenge = {
   satoshisRequired: 1000,
   serverIdentityKey: "02c0d1f9a09e0f6f5e1d8b3d3f9c6c5c1e4b2a0f8d7e6c5b4a3928170605041234",
   derivationPrefix: "AQID",
+  authenticated: false,
 }
 
 // Known compressed public key (33 bytes hex) for testing locking script derivation
@@ -138,16 +139,27 @@ describe("constructBrc105Proof", () => {
     expect(proof.txid).toBe("aabbccdd")
   })
 
-  it("calls getPublicKey with correct BRC-29 derivation parameters", async () => {
+  it("calls getPublicKey with 'anyone' counterparty in no-auth mode", async () => {
     const wallet = mockWallet()
     await constructBrc105Proof(CHALLENGE, wallet)
 
     expect(wallet.getPublicKey).toHaveBeenCalledOnce()
     const call = (wallet.getPublicKey as ReturnType<typeof vi.fn>).mock.calls[0][0]
     expect(call.protocolID).toEqual([2, "3241645161d8"])
-    expect(call.counterparty).toBe(CHALLENGE.serverIdentityKey)
+    expect(call.counterparty).toBe("anyone")
     // keyID must be "${prefix} ${suffix}" (space-separated)
     expect(call.keyID).toMatch(new RegExp(`^${CHALLENGE.derivationPrefix} .+$`))
+  })
+
+  it("calls getPublicKey with server identity key counterparty in authenticated mode", async () => {
+    const wallet = mockWallet()
+    const authChallenge = { ...CHALLENGE, authenticated: true }
+    await constructBrc105Proof(authChallenge, wallet)
+
+    expect(wallet.getPublicKey).toHaveBeenCalledOnce()
+    const call = (wallet.getPublicKey as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(call.protocolID).toEqual([2, "3241645161d8"])
+    expect(call.counterparty).toBe(authChallenge.serverIdentityKey)
   })
 
   it("uses space-separated keyID format (static test vector)", async () => {

--- a/src/brc105-proof.ts
+++ b/src/brc105-proof.ts
@@ -216,11 +216,14 @@ export async function constructBrc105Proof(
   const derivationSuffix = await createDerivationSuffix(wallet)
 
   // Step 2: Derive the payee's public key via BRC-29
+  // In no-auth mode (no BRC-103), both client and server use "anyone" as
+  // counterparty. With BRC-103, the server's identity key is the counterparty.
+  const counterparty = challenge.authenticated ? challenge.serverIdentityKey : "anyone"
   const keyID = `${challenge.derivationPrefix} ${derivationSuffix}`
   const { publicKey: derivedPublicKey } = await wallet.getPublicKey({
     protocolID: [2, "3241645161d8"],
     keyID,
-    counterparty: challenge.serverIdentityKey,
+    counterparty,
   })
 
   // Step 3: Build P2PKH locking script

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface Brc105Challenge {
   satoshisRequired: number
   serverIdentityKey: string
   derivationPrefix: string
+  /** Whether the identity key came from BRC-103 auth (vs standalone x-bsv-payment-identity-key). */
+  authenticated: boolean
 }
 
 /** Minimal wallet interface for BRC-105 proof construction.


### PR DESCRIPTION
## Summary

- Added `authenticated` flag to `Brc105Challenge`, derived from which header provided the identity key (`x-bsv-auth-identity-key` → true, `x-bsv-payment-identity-key` → false)
- Proof construction now uses `"anyone"` as counterparty when not authenticated, matching x402-rack's `resolve_counterparty` behaviour
- With BRC-103 auth, the server's identity key is still used as counterparty

Closes #59

## Test plan

- [x] `npm test` — 210 tests pass (1 new test for authenticated counterparty)
- [x] `npm run build:all` — library + all 3 browser extensions build clean
- [ ] Live test with x402-doom: payment address should now match server's derived address

🤖 Generated with [Claude Code](https://claude.com/claude-code)