### PR TITLE
fix: remove UTXO import dedup — unnecessary with HTTP fix

### DIFF
--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -70,6 +70,9 @@ async function pubkeyToAddress(pubkeyHex: string): Promise<string> {
 // ---------------------------------------------------------------------------
 
 async function scanAndImportUtxos(): Promise<void> {
+  // Clean up orphaned storage from previous dedup implementations (#55, #57)
+  chrome.storage.local.remove(['x402_funded_addresses', 'x402_imported_outpoints'])
+
   const rootKeyHex = wallet.getRootKeyHex()
   if (!rootKeyHex) return
 


### PR DESCRIPTION
## Summary

- Removed `x402_imported_outpoints` storage tracking and all dedup logic
- UTXO scan now imports all on-chain UTXOs found on every unlock
- Wallet handles dedup naturally (rejects double-spends, retries after failed txs)

The dedup was masking a balance discrepancy caused by the upstream HTTP client bug (bsv-blockchain/ts-sdk#509). With the SDK patched, sweep txs broadcast successfully and the dedup is unnecessary.

Closes #68

## Test plan

- [x] All 210 tests pass
- [x] All 3 browser extensions build clean
- [ ] Verify balance matches on-chain after unlock with patched SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)