### PR TITLE
fix: patch @bsv/sdk for service worker HTTP client detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build:safari": "tsx plugins/build.ts --target safari",
     "build:all": "npm run build && npm run build:plugins",
     "demo": "npm run build && tsx demo/server.ts",
-    "docs": "typedoc"
+    "docs": "typedoc",
+    "postinstall": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -37,6 +38,7 @@
     "@types/chrome": "^0.1.38",
     "@types/express": "^5.0.6",
     "express": "^5.2.1",
+    "patch-package": "^8.0.1",
     "tsup": "^8.0.0",
     "tsx": "^4.21.0",
     "typedoc": "^0.28.18",

--- a/patches/@bsv+sdk+2.0.13.patch
+++ b/patches/@bsv+sdk+2.0.13.patch
@@ -1,0 +1,76 @@
+diff --git a/node_modules/@bsv/sdk/dist/cjs/src/transaction/http/BinaryFetchClient.js b/node_modules/@bsv/sdk/dist/cjs/src/transaction/http/BinaryFetchClient.js
+index fef0036..de7a1bb 100644
+--- a/node_modules/@bsv/sdk/dist/cjs/src/transaction/http/BinaryFetchClient.js
++++ b/node_modules/@bsv/sdk/dist/cjs/src/transaction/http/BinaryFetchClient.js
+@@ -46,9 +46,13 @@ function binaryHttpClient() {
+         }
+     };
+     if (typeof window !== 'undefined' && typeof window.fetch === 'function') {
+-        // Use fetch in a browser environment
++        // Browser tab/page context
+         return new BinaryFetchClient(window.fetch.bind(window));
+     }
++    else if (typeof globalThis.fetch === 'function') {
++        // Service workers, Deno, Node 18+
++        return new BinaryFetchClient(globalThis.fetch.bind(globalThis));
++    }
+     else if (typeof require !== 'undefined') {
+         // Use Node https module
+         // eslint-disable-next-line
+diff --git a/node_modules/@bsv/sdk/dist/cjs/src/transaction/http/DefaultHttpClient.js b/node_modules/@bsv/sdk/dist/cjs/src/transaction/http/DefaultHttpClient.js
+index 9ddbd32..9f7be15 100644
+--- a/node_modules/@bsv/sdk/dist/cjs/src/transaction/http/DefaultHttpClient.js
++++ b/node_modules/@bsv/sdk/dist/cjs/src/transaction/http/DefaultHttpClient.js
+@@ -15,9 +15,13 @@ function defaultHttpClient() {
+         }
+     };
+     if (typeof window !== 'undefined' && typeof window.fetch === 'function') {
+-        // Use fetch in a browser environment
++        // Browser tab/page context
+         return new FetchHttpClient_js_1.FetchHttpClient(window.fetch.bind(window));
+     }
++    else if (typeof globalThis.fetch === 'function') {
++        // Service workers, Deno, Node 18+
++        return new FetchHttpClient_js_1.FetchHttpClient(globalThis.fetch.bind(globalThis));
++    }
+     else if (typeof require !== 'undefined') {
+         // Use Node https module
+         // eslint-disable-next-line
+diff --git a/node_modules/@bsv/sdk/dist/esm/src/transaction/http/BinaryFetchClient.js b/node_modules/@bsv/sdk/dist/esm/src/transaction/http/BinaryFetchClient.js
+index ca11bc0..a390b06 100644
+--- a/node_modules/@bsv/sdk/dist/esm/src/transaction/http/BinaryFetchClient.js
++++ b/node_modules/@bsv/sdk/dist/esm/src/transaction/http/BinaryFetchClient.js
+@@ -42,9 +42,13 @@ export function binaryHttpClient() {
+         }
+     };
+     if (typeof window !== 'undefined' && typeof window.fetch === 'function') {
+-        // Use fetch in a browser environment
++        // Browser tab/page context
+         return new BinaryFetchClient(window.fetch.bind(window));
+     }
++    else if (typeof globalThis.fetch === 'function') {
++        // Service workers, Deno, Node 18+
++        return new BinaryFetchClient(globalThis.fetch.bind(globalThis));
++    }
+     else if (typeof require !== 'undefined') {
+         // Use Node https module
+         // eslint-disable-next-line
+diff --git a/node_modules/@bsv/sdk/dist/esm/src/transaction/http/DefaultHttpClient.js b/node_modules/@bsv/sdk/dist/esm/src/transaction/http/DefaultHttpClient.js
+index 77d580a..8cea149 100644
+--- a/node_modules/@bsv/sdk/dist/esm/src/transaction/http/DefaultHttpClient.js
++++ b/node_modules/@bsv/sdk/dist/esm/src/transaction/http/DefaultHttpClient.js
+@@ -12,9 +12,13 @@ export function defaultHttpClient() {
+         }
+     };
+     if (typeof window !== 'undefined' && typeof window.fetch === 'function') {
+-        // Use fetch in a browser environment
++        // Browser tab/page context
+         return new FetchHttpClient(window.fetch.bind(window));
+     }
++    else if (typeof globalThis.fetch === 'function') {
++        // Service workers, Deno, Node 18+
++        return new FetchHttpClient(globalThis.fetch.bind(globalThis));
++    }
+     else if (typeof require !== 'undefined') {
+         // Use Node https module
+         // eslint-disable-next-line


### PR DESCRIPTION
## Summary

- Added `patch-package` with a patch for `@bsv/sdk@2.0.13`
- Adds `globalThis.fetch` fallback in `defaultHttpClient()` and `binaryHttpClient()` for service worker, Deno, and Node 18+ contexts
- Fixes ARC broadcast, merkle proof fetching, and all HTTP operations from the extension's service worker

Without this patch, the wallet-toolbox cannot make any HTTP requests from the service worker, causing sweep transactions to fail and UTXOs to become stuck.

Upstream: [bsv-blockchain/ts-sdk#509](https://github.com/bsv-blockchain/ts-sdk/issues/509) / [bsv-blockchain/ts-sdk#510](https://github.com/bsv-blockchain/ts-sdk/pull/510)

## Test plan

- [x] All 210 tests pass
- [x] All 3 browser extensions build with `globalThis.fetch` in bundled output
- [ ] Verify service worker HTTP requests succeed after extension reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)