### PR TITLE
fix: send x-bsv-auth-identity-key header in BRC-105 retry

### DIFF
--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -425,6 +425,9 @@ describe("createX402Fetch — BRC-105", () => {
     expect(proof).toHaveProperty("derivationSuffix")
     expect(proof).toHaveProperty("transaction")
     expect(proof.clientIdentityKey).toBe("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+
+    // Verify x-bsv-auth-identity-key header is set separately
+    expect(retryHeaders.get("x-bsv-auth-identity-key")).toBe("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
   })
 
   it("blocks BRC-105 402 exceeding per-tx limit", async () => {

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -349,6 +349,7 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
         (proof) => {
           const headers = new Headers(init?.headers)
           headers.set("x-bsv-payment", JSON.stringify(proof))
+          headers.set("x-bsv-auth-identity-key", (proof as import("./types").Brc105Proof).clientIdentityKey)
           return fetch(input, { ...init, headers })
         },
         (proof) => ({


### PR DESCRIPTION
Sends the client identity key as a separate x-bsv-auth-identity-key HTTP header alongside the x-bsv-payment JSON. x402-rack reads it from the header, not the JSON body.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)