### PR TITLE
fix: set ARC-compatible fee model (100 sat/kb)

### DIFF
--- a/plugins/shared/builtin-wallet-backend.ts
+++ b/plugins/shared/builtin-wallet-backend.ts
@@ -46,6 +46,8 @@ export class BuiltInWalletBackend implements WalletBackend {
       rootKeyHex,
       databaseName: `x402-wallet-${chain}`,
     })
+    // ARC requires minimum 100 sat/kb; wallet-toolbox defaults to 1 sat/kb
+    result.activeStorage.feeModel = { model: 'sat/kb', value: 100 }
     this.wallet = result.wallet
     this.monitor = result.monitor
     // Start the monitor in the background (don't block unlock)


### PR DESCRIPTION
wallet-toolbox defaults to 1 sat/kb which ARC rejects as insufficient fees. Sets 100 sat/kb on the active storage after wallet creation.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)