### PR TITLE
fix: reset auto-lock timer on CWI activity

### DIFF
--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -246,6 +246,9 @@ chrome.runtime.onMessage.addListener(
         return true
       }
 
+      // Reset idle timer — wallet is actively being used
+      chrome.alarms.create('auto-lock', { periodInMinutes: 15 })
+
       handleCWIRequest(message, wallet.getBackend(), sender.tab?.id)
         .then((response) => sendResponse(response))
         .catch((err) => {


### PR DESCRIPTION
Resets the 15-minute auto-lock countdown on every CWI call so the wallet only locks after genuine idle, not mid-gameplay.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)