### PR TITLE
fix: don't pass originator to built-in wallet — prevents approval gates

### DIFF
--- a/plugins/shared/builtin-wallet-backend.ts
+++ b/plugins/shared/builtin-wallet-backend.ts
@@ -76,12 +76,14 @@ export class BuiltInWalletBackend implements WalletBackend {
 
     // Delegate to the wallet-toolbox Wallet instance
     // All BRC-100 methods follow the pattern: wallet.method(args, originator?)
+    // No originator — the built-in wallet is ours, not an external app.
+    // Our CWI proxy handles spending limits; the wallet doesn't need to gate.
     const fn = (this.wallet as unknown as Record<string, Function>)[method]
     if (typeof fn !== 'function') {
       throw new Error(`Wallet does not implement method: ${method}`)
     }
 
-    return fn.call(this.wallet, params ?? {}, origin || undefined)
+    return fn.call(this.wallet, params ?? {})
   }
 
   async isAuthenticated(): Promise<boolean> {


### PR DESCRIPTION
Stop passing page origin as originator to wallet-toolbox. Our CWI proxy handles spending limits; the wallet's own approval gates (10 tx/minute) were blocking mid-gameplay.

Closes #82, closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)