### PR TITLE
feat: show version and git ref in popup footer

### DIFF
--- a/plugins/build.ts
+++ b/plugins/build.ts
@@ -3,12 +3,18 @@ import { cpSync, mkdirSync, existsSync, renameSync, readdirSync } from 'fs'
 import { resolve, join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
+import { readFileSync } from 'fs'
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const ROOT = resolve(__dirname, '..')
 const PLUGINS = resolve(__dirname)
 const DIST = resolve(ROOT, 'dist', 'plugins')
 const SHARED = resolve(PLUGINS, 'shared')
+
+// Build-time constants for version display
+const PKG_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).version
+const GIT_REF = execSync('git rev-parse --short HEAD', { cwd: ROOT }).toString().trim()
 
 type Target = 'chromium' | 'firefox' | 'safari'
 const ALL_TARGETS: Target[] = ['chromium', 'firefox', 'safari']
@@ -54,7 +60,7 @@ function buildTarget(target: Target) {
   for (const { src, outDir: scriptOutDir } of uiScripts) {
     if (existsSync(src)) {
       mkdirSync(scriptOutDir, { recursive: true })
-      execSync(`npx tsup ${src} --out-dir ${scriptOutDir} --format iife --target es2020 --no-splitting --no-dts --clean false`, { cwd: ROOT, stdio: 'inherit' })
+      execSync(`npx tsup ${src} --out-dir ${scriptOutDir} --format iife --target es2020 --no-splitting --no-dts --clean false --define.__X402_VERSION__ '"${PKG_VERSION}"' --define.__X402_GIT_REF__ '"${GIT_REF}"'`, { cwd: ROOT, stdio: 'inherit' })
     }
   }
 

--- a/plugins/shared/ui/popup.html
+++ b/plugins/shared/ui/popup.html
@@ -86,7 +86,7 @@
     </div>
 
     <footer>
-      <span class="footer-text">x402 Wallet</span>
+      <span class="footer-text">x402 Wallet <span id="version-info"></span></span>
     </footer>
   </div>
 

--- a/plugins/shared/ui/popup.ts
+++ b/plugins/shared/ui/popup.ts
@@ -137,6 +137,10 @@ function sendMessage(msg: Record<string, unknown>): Promise<PopupState> {
   });
 }
 
+// Build-time constants injected by tsup --define
+declare const __X402_VERSION__: string;
+declare const __X402_GIT_REF__: string;
+
 // ---------------------------------------------------------------------------
 // Initialisation
 // ---------------------------------------------------------------------------
@@ -194,6 +198,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       network: "mainnet",
       tier: "Hey, Not Too Rough",
     });
+  }
+
+  // Display version + git ref in footer
+  const versionEl = document.getElementById("version-info");
+  if (versionEl) {
+    versionEl.textContent = `v${__X402_VERSION__} (${__X402_GIT_REF__})`;
   }
 
   // Poll balance every 10s while popup is open


### PR DESCRIPTION
Injects package version and short git hash at build time. Footer shows e.g. 'x402 Wallet v0.5.0 (a737235)'.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)