### PR TITLE
fix: Firefox MV3 background.service_worker → background.scripts

### DIFF
--- a/plugins/firefox/manifest.json
+++ b/plugins/firefox/manifest.json
@@ -6,7 +6,7 @@
   "permissions": ["storage", "alarms"],
   "host_permissions": ["<all_urls>"],
   "background": {
-    "service_worker": "background.js",
+    "scripts": ["background.js"],
     "type": "module"
   },
   "content_scripts": [{


### PR DESCRIPTION
Firefox MV3 doesn't support `background.service_worker` yet — it requires `background.scripts` with `type: module` (ESM event page model). Chromium and Safari keep `background.service_worker`.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)