### PR TITLE
fix: Firefox CWI Xray compatibility, autospend UI, popup height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/plugins/
 .mcp.json
 tmp/
 docs/
+plugins/safari/xcode/project/

--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -196,6 +196,8 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
       const payload = message.payload as { password: string } | undefined
       if (!payload?.password) throw new Error('Password required')
       await wallet.unlock(payload.password)
+      // Clamp autospend balance to actual wallet balance
+      x402.clampToWallet(await getWalletBalance())
       // Scan for legacy P2PKH UTXOs in the background (don't block unlock)
       scanAndImportUtxos().catch((err) => {
         console.warn('x402: UTXO scan failed (non-blocking):', err)
@@ -264,7 +266,8 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
 
   // All internal messages return composed state from both controllers
   const walletState = await wallet.getWalletState()
-  const x402State = x402.getX402State()
+  const walletBal = wallet.isUnlocked() ? await getWalletBalance() : undefined
+  const x402State = x402.getX402State(walletBal)
   return { ...walletState, ...x402State }
 }
 
@@ -310,7 +313,8 @@ chrome.runtime.onMessage.addListener(
 
     // Spend status — allowed from content scripts (for the indicator)
     if (isInternalMessage(message) && message.type === 'getSpendStatus') {
-      sendResponse(x402.getSpendStatus())
+      const bal = wallet.isUnlocked() ? getWalletBalance() : Promise.resolve(undefined)
+      bal.then((wb) => sendResponse(x402.getSpendStatus(wb))).catch(() => sendResponse(x402.getSpendStatus()))
       return true
     }
 

--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -249,7 +249,7 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
       const result = await backend.call('getPublicKey', { identityKey: true }, 'self') as { publicKey: string }
       const address = await pubkeyToAddress(result.publicKey)
       const walletState = await wallet.getWalletState()
-      const x402State = x402.getX402State()
+      const x402State = x402.getX402State(await getWalletBalance())
       return { ...walletState, ...x402State, identityKey: result.publicKey, address }
     }
 
@@ -266,7 +266,9 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
 
   // All internal messages return composed state from both controllers
   const walletState = await wallet.getWalletState()
-  const walletBal = wallet.isUnlocked() ? await getWalletBalance() : undefined
+  const walletBal = wallet.isUnlocked() && walletState.balance !== undefined
+    ? Number(walletState.balance) || 0
+    : undefined
   const x402State = x402.getX402State(walletBal)
   return { ...walletState, ...x402State }
 }
@@ -314,7 +316,7 @@ chrome.runtime.onMessage.addListener(
     // Spend status — allowed from content scripts (for the indicator)
     if (isInternalMessage(message) && message.type === 'getSpendStatus') {
       const bal = wallet.isUnlocked() ? getWalletBalance() : Promise.resolve(undefined)
-      bal.then((wb) => sendResponse(x402.getSpendStatus(wb))).catch(() => sendResponse(x402.getSpendStatus()))
+      bal.then((wb) => sendResponse(x402.getSpendStatus(wb))).catch(() => sendResponse(x402.getSpendStatus(0)))
       return true
     }
 

--- a/plugins/shared/content-script.ts
+++ b/plugins/shared/content-script.ts
@@ -10,6 +10,26 @@ import {
 import { SpendIndicator, type SpendStatus, type IndicatorMode } from './spend-indicator';
 
 // ---------------------------------------------------------------------------
+// Firefox Xray compatibility
+//
+// In Firefox, objects created in the content script's compartment are not
+// directly accessible to page scripts — reading a property raises
+// "Permission denied to access property". To expose an object via
+// CustomEvent.detail, we must clone it into the page's compartment using
+// the Firefox-only global `cloneInto`. On Chrome/Safari, `cloneInto` is
+// undefined and objects cross the content/page boundary freely, so we pass
+// the detail through as-is.
+// ---------------------------------------------------------------------------
+
+declare const cloneInto: (<T>(obj: T, targetScope: unknown) => T) | undefined;
+
+function dispatchToPage(eventName: string, detail: unknown): void {
+  const payload =
+    typeof cloneInto === 'function' ? cloneInto(detail, window) : detail;
+  document.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
+}
+
+// ---------------------------------------------------------------------------
 // 1. Inject the page script into the page context (runs at document_start)
 // ---------------------------------------------------------------------------
 
@@ -55,15 +75,11 @@ document.addEventListener(CWI_REQUEST_EVENT, (evt: Event) => {
           status: 'error',
           error: chrome.runtime.lastError?.message ?? 'No response from background',
         };
-        document.dispatchEvent(
-          new CustomEvent(CWI_RESPONSE_EVENT, { detail: errorResponse }),
-        );
+        dispatchToPage(CWI_RESPONSE_EVENT, errorResponse);
         return;
       }
 
-      document.dispatchEvent(
-        new CustomEvent(CWI_RESPONSE_EVENT, { detail: response }),
-      );
+      dispatchToPage(CWI_RESPONSE_EVENT, response);
     });
   } catch {
     const errorResponse: CWIResponse = {
@@ -71,9 +87,7 @@ document.addEventListener(CWI_REQUEST_EVENT, (evt: Event) => {
       status: 'error',
       error: 'Extension context invalidated',
     };
-    document.dispatchEvent(
-      new CustomEvent(CWI_RESPONSE_EVENT, { detail: errorResponse }),
-    );
+    dispatchToPage(CWI_RESPONSE_EVENT, errorResponse);
   }
 });
 

--- a/plugins/shared/pending-approvals.ts
+++ b/plugins/shared/pending-approvals.ts
@@ -72,7 +72,7 @@ export function requestApproval(req: ApprovalRequest): Promise<boolean> {
         url,
         type: 'popup',
         width: 400,
-        height: 320,
+        height: 500,
       }, (window) => {
         if (chrome.runtime.lastError || !window?.id) {
           console.warn('x402: failed to open approval popup, auto-denying:', chrome.runtime.lastError?.message)

--- a/plugins/shared/ui/popup.ts
+++ b/plugins/shared/ui/popup.ts
@@ -193,6 +193,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   function updateUI(state: PopupState): void {
     updateWalletPanel(state);
     updateX402Panel(state);
+
+    // Hide x402 panel when wallet is locked — autospend is meaningless without a wallet
+    const x402Panel = document.getElementById("x402-panel");
+    if (x402Panel) x402Panel.hidden = !state.isUnlocked;
   }
 
   try {

--- a/plugins/shared/x402-controller.ts
+++ b/plugins/shared/x402-controller.ts
@@ -79,30 +79,39 @@ export function resetAutospend(walletBalance: number): void {
   state = initialState(config, walletBalance)
 }
 
+/** Clamp the autospend balance to the wallet balance (e.g. after unlock). */
+export function clampToWallet(walletBalance: number): void {
+  state = clampFn(state, config, walletBalance)
+}
+
 /** Get current autospend state for UI. */
-export function getX402State(): {
+export function getX402State(walletBalance?: number): {
   tier: TierName
   weapon: WeaponName
   autospendBalance: number
   tierCap: number
   weaponCap: number
 } {
+  const rawTierCap = TIER_CAPS[config.tier]
+  // Effective cap: never exceed wallet balance when known
+  const tierCap = walletBalance !== undefined ? Math.min(rawTierCap, walletBalance) : rawTierCap
   return {
     tier: config.tier,
     weapon: config.weapon,
     autospendBalance: state.balance,
-    tierCap: TIER_CAPS[config.tier],
+    tierCap,
     weaponCap: WEAPON_CAPS[config.weapon],
   }
 }
 
 /** Get spend status for the indicator (balance as % of tier cap). */
-export function getSpendStatus(): {
+export function getSpendStatus(walletBalance?: number): {
   balance: number
   tierCap: number
   percentage: number
 } {
-  const tierCap = TIER_CAPS[config.tier]
+  const rawTierCap = TIER_CAPS[config.tier]
+  const tierCap = walletBalance !== undefined ? Math.min(rawTierCap, walletBalance) : rawTierCap
   return {
     balance: state.balance,
     tierCap,


### PR DESCRIPTION
## Summary

- **Firefox CWI Xray fix (#95):** Clone CWI response objects into the page compartment using `cloneInto()` so Firefox page scripts can read properties without "Permission denied" errors
- **Autospend UI when locked/underfunded (#96):** Hide the x402 panel when wallet is locked; clamp autospend balance to actual wallet balance on unlock so it never shows more than the wallet holds
- **Approval popup cropping:** Window height was 320px but content needs 500px — bottom of dialogue was cut off on all browsers

## Test plan

- [ ] Firefox: verify `window.CWI` methods work without "Permission denied" errors
- [ ] Open popup with locked wallet — x402 panel should be hidden
- [ ] Unlock wallet with balance < tier cap — autospend should show wallet balance, not tier cap
- [ ] Trigger approval popup — full dialogue visible without cropping
- [ ] Safari: build and load in Xcode, verify basic functionality

Closes #95
Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)