### PR TITLE
feat: custom X402 proof sends base64 BEEF instead of rawTx

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface Challenge {
 
 export interface Proof {
   txid: string
-  rawTx: string
+  beef: string  // base64-encoded AtomicBEEF
 }
 
 // === BRC-105 payment protocol ===

--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -51,17 +51,22 @@ describe("createX402Fetch", () => {
       .mockResolvedValueOnce(make402Response(1000))
       .mockResolvedValueOnce(make200Response())
 
-    const proofConstructor = vi.fn().mockResolvedValue({ txid: "mock-txid", rawTx: "00" })
+    const proofConstructor = vi.fn().mockResolvedValue({ txid: "mock-txid", beef: btoa("mock-tx") })
     const f = createX402Fetch({ proofConstructor })
 
     const res = await f("https://api.example.com/data")
     expect(res.status).toBe(200)
     expect(proofConstructor).toHaveBeenCalledOnce()
 
-    // Verify the retry request has X402-Proof header
+    // Verify the retry request has X402-Proof header with beef field
     const retryCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
     const retryHeaders = retryCall[1]?.headers as Headers
-    expect(retryHeaders.get("X402-Proof")).toBeTruthy()
+    const proofHeader = retryHeaders.get("X402-Proof")
+    expect(proofHeader).toBeTruthy()
+    const proof = JSON.parse(proofHeader!)
+    expect(proof).toHaveProperty("txid", "mock-txid")
+    expect(proof).toHaveProperty("beef", btoa("mock-tx"))
+    expect(proof).not.toHaveProperty("rawTx")
   })
 
   it("returns original 402 when proof construction fails", async () => {
@@ -127,6 +132,141 @@ describe("payeeAddressToLockingScript", () => {
   it("rejects unsupported version byte", () => {
     expect(() => payeeAddressToLockingScript("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"))
       .toThrow("Unsupported address version")
+  })
+})
+
+// === defaultConstructProof tests (via CWI mock) ===
+
+function make402WithValidAddress(amount: number = 1000) {
+  return new Response("Payment Required", {
+    status: 402,
+    headers: {
+      "X402-Challenge": JSON.stringify({
+        nonce: "test-nonce",
+        payee: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+        amount,
+        network: "mainnet",
+      }),
+    },
+  })
+}
+
+describe("defaultConstructProof (via CWI)", () => {
+  let originalFetch: typeof globalThis.fetch
+  let originalCWI: any
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    originalCWI = (globalThis as any).CWI
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    ;(globalThis as any).CWI = originalCWI
+  })
+
+  it("converts tx (number[]) to base64 beef (modern wallet)", async () => {
+    const txBytes = [0xca, 0xfe]
+    ;(globalThis as any).CWI = {
+      createAction: vi.fn().mockResolvedValue({ txid: "abc123", tx: txBytes }),
+    }
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(make402WithValidAddress())
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch()
+    const res = await f("https://api.example.com/data")
+    expect(res.status).toBe(200)
+
+    const retryCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    const retryHeaders = retryCall[1]?.headers as Headers
+    const proof = JSON.parse(retryHeaders.get("X402-Proof")!)
+    expect(proof.txid).toBe("abc123")
+    // base64 of [0xca, 0xfe]
+    const expectedBase64 = btoa(String.fromCharCode(0xca, 0xfe))
+    expect(proof.beef).toBe(expectedBase64)
+    expect(proof).not.toHaveProperty("rawTx")
+  })
+
+  it("converts rawTx hex to base64 beef (legacy wallet)", async () => {
+    ;(globalThis as any).CWI = {
+      createAction: vi.fn().mockResolvedValue({ txid: "abc123", rawTx: "deadbeef" }),
+    }
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(make402WithValidAddress())
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch()
+    const res = await f("https://api.example.com/data")
+    expect(res.status).toBe(200)
+
+    const retryCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    const retryHeaders = retryCall[1]?.headers as Headers
+    const proof = JSON.parse(retryHeaders.get("X402-Proof")!)
+    expect(proof.txid).toBe("abc123")
+    // base64 of [0xde, 0xad, 0xbe, 0xef]
+    const expectedBase64 = btoa(String.fromCharCode(0xde, 0xad, 0xbe, 0xef))
+    expect(proof.beef).toBe(expectedBase64)
+  })
+
+  it("prefers tx over rawTx when both present", async () => {
+    const txBytes = [0xca]
+    ;(globalThis as any).CWI = {
+      createAction: vi.fn().mockResolvedValue({ txid: "abc123", tx: txBytes, rawTx: "dead" }),
+    }
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(make402WithValidAddress())
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch()
+    const res = await f("https://api.example.com/data")
+    expect(res.status).toBe(200)
+
+    const retryCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    const retryHeaders = retryCall[1]?.headers as Headers
+    const proof = JSON.parse(retryHeaders.get("X402-Proof")!)
+    // Should use tx, not rawTx
+    const expectedBase64 = btoa(String.fromCharCode(0xca))
+    expect(proof.beef).toBe(expectedBase64)
+  })
+
+  it("throws when neither tx nor rawTx present", async () => {
+    ;(globalThis as any).CWI = {
+      createAction: vi.fn().mockResolvedValue({ txid: "abc123" }),
+    }
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(make402WithValidAddress())
+
+    const onProofError = vi.fn()
+    const f = createX402Fetch({ onProofError })
+    const res = await f("https://api.example.com/data")
+
+    // Should fall back to returning the original 402
+    expect(res.status).toBe(402)
+    expect(onProofError).toHaveBeenCalledOnce()
+    expect(onProofError.mock.calls[0][0]).toBeInstanceOf(Error)
+    expect((onProofError.mock.calls[0][0] as Error).message).toMatch(/no transaction data/i)
+  })
+
+  it("throws when tx is empty array and rawTx absent", async () => {
+    ;(globalThis as any).CWI = {
+      createAction: vi.fn().mockResolvedValue({ txid: "abc123", tx: [] }),
+    }
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(make402WithValidAddress())
+
+    const onProofError = vi.fn()
+    const f = createX402Fetch({ onProofError })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(402)
+    expect(onProofError).toHaveBeenCalledOnce()
+    expect((onProofError.mock.calls[0][0] as Error).message).toMatch(/no transaction data/i)
   })
 })
 
@@ -221,7 +361,7 @@ describe("createX402Fetch — BRC-105", () => {
       .mockResolvedValueOnce(bothHeaders)
       .mockResolvedValueOnce(make200Response())
 
-    const customProof = vi.fn().mockResolvedValue({ txid: "custom-txid", rawTx: "00" })
+    const customProof = vi.fn().mockResolvedValue({ txid: "custom-txid", beef: btoa("mock-tx") })
     const brc105Proof = mockBrc105ProofConstructor()
 
     const f = createX402Fetch({

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -10,6 +10,26 @@ import type {
 
 // === Proof construction via BRC-100 wallet (window.CWI) ===
 
+// Base64/hex helpers (inlined to avoid cross-module dependency on brc105-proof)
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ""
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary)
+}
+
+function numberArrayToBase64(arr: number[]): string {
+  return bytesToBase64(new Uint8Array(arr))
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error("Hex string must have even length")
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16)
+  }
+  return bytes
+}
+
 const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 function base58DecodeCheck(address: string): { version: number; payload: Uint8Array } {
@@ -95,13 +115,20 @@ async function defaultConstructProof(challenge: Challenge): Promise<Proof> {
     throw new Error("Wallet declined payment or returned invalid result")
   }
 
-  if (!result.rawTx || typeof result.rawTx !== "string" || result.rawTx.length === 0) {
-    throw new Error("Wallet did not return raw transaction")
+  // Convert transaction to base64 BEEF
+  // SDK wallets return `tx: number[]`; CWI wallets return `rawTx: string` (hex)
+  let beef: string
+  if (result.tx && Array.isArray(result.tx) && result.tx.length > 0) {
+    beef = numberArrayToBase64(result.tx)
+  } else if (result.rawTx && typeof result.rawTx === "string" && result.rawTx.length > 0) {
+    beef = bytesToBase64(hexToBytes(result.rawTx))
+  } else {
+    throw new Error("Wallet returned no transaction data (neither tx nor rawTx)")
   }
 
   return {
     txid: result.txid,
-    rawTx: result.rawTx,
+    beef,
   }
 }
 


### PR DESCRIPTION
## Summary

- **Proof type** updated: `{ txid, beef }` replaces `{ txid, rawTx }` -- `beef` is base64-encoded AtomicBEEF
- **`defaultConstructProof`** reads `result.tx` (modern wallets, `number[]`) with `result.rawTx` fallback (legacy hex)
- **5 new tests** covering tx-only, rawTx-fallback, both-present, neither-throws, empty-tx edge cases
- **BRC-105 path** completely unaffected

### Coordination
x402-rack `PayGateway` needs a matching update to read `proof["beef"]` (base64) instead of `proof["rawTx"]` (hex).

## Test plan
- [x] All 179 tests pass
- [x] TypeScript compiles cleanly (main + plugins)
- [x] New edge case tests verify proof format
- [x] BRC-105 tests unchanged and passing

Closes #98
