### PR TITLE
feat: two-phase BRC-105 payment — noSend + abort on server rejection

### DIFF
--- a/src/brc105-proof.test.ts
+++ b/src/brc105-proof.test.ts
@@ -127,7 +127,7 @@ describe("createDerivationSuffix", () => {
 describe("constructBrc105Proof", () => {
   it("returns correct proof shape including clientIdentityKey", async () => {
     const wallet = mockWallet()
-    const proof = await constructBrc105Proof(CHALLENGE, wallet)
+    const { proof } = await constructBrc105Proof(CHALLENGE, wallet)
 
     expect(proof).toHaveProperty("derivationPrefix")
     expect(proof).toHaveProperty("derivationSuffix")
@@ -214,7 +214,7 @@ describe("constructBrc105Proof", () => {
 
   it("includes customInstructions with derivation data and payee", async () => {
     const wallet = mockWallet()
-    const proof = await constructBrc105Proof(CHALLENGE, wallet)
+    const { proof } = await constructBrc105Proof(CHALLENGE, wallet)
 
     const params = (wallet.createAction as ReturnType<typeof vi.fn>).mock.calls[0][0]
     const instructions = JSON.parse(params.outputs[0].customInstructions)
@@ -231,12 +231,39 @@ describe("constructBrc105Proof", () => {
     expect(params.options.randomizeOutputs).toBe(false)
   })
 
+  it("calls createAction with noSend: true and returnTXIDOnly: false", async () => {
+    const wallet = mockWallet()
+    await constructBrc105Proof(CHALLENGE, wallet)
+
+    const params = (wallet.createAction as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(params.options.noSend).toBe(true)
+    expect(params.options.returnTXIDOnly).toBe(false)
+  })
+
+  it("returns abort callback when wallet has abortAction", async () => {
+    const wallet = mockWallet({
+      abortAction: vi.fn().mockResolvedValue({ aborted: true }),
+    })
+    const { proof, abort } = await constructBrc105Proof(CHALLENGE, wallet)
+
+    expect(proof).toBeDefined()
+    expect(abort).toBeDefined()
+  })
+
+  it("returns undefined abort when wallet lacks abortAction", async () => {
+    const wallet = mockWallet()
+    const { proof, abort } = await constructBrc105Proof(CHALLENGE, wallet)
+
+    expect(proof).toBeDefined()
+    expect(abort).toBeUndefined()
+  })
+
   it("handles rawTx hex string → base64 conversion", async () => {
     const rawTxHex = "deadbeef"
     const wallet = mockWallet({
       createAction: vi.fn().mockResolvedValue({ txid: "aabb", rawTx: rawTxHex }),
     })
-    const proof = await constructBrc105Proof(CHALLENGE, wallet)
+    const { proof } = await constructBrc105Proof(CHALLENGE, wallet)
 
     // deadbeef → base64 = "3q2+7w=="
     const decoded = atob(proof.transaction)
@@ -256,7 +283,7 @@ describe("constructBrc105Proof", () => {
     const wallet = mockWallet({
       createAction: vi.fn().mockResolvedValue({ txid: "aabb", tx: txBytes }),
     })
-    const proof = await constructBrc105Proof(CHALLENGE, wallet)
+    const { proof } = await constructBrc105Proof(CHALLENGE, wallet)
 
     const decoded = atob(proof.transaction)
     const bytes = Array.from(decoded).map((c) => c.charCodeAt(0))
@@ -272,7 +299,7 @@ describe("constructBrc105Proof", () => {
         rawTx: "deadbeef",
       }),
     })
-    const proof = await constructBrc105Proof(CHALLENGE, wallet)
+    const { proof } = await constructBrc105Proof(CHALLENGE, wallet)
 
     const decoded = atob(proof.transaction)
     const bytes = Array.from(decoded).map((c) => c.charCodeAt(0))

--- a/src/brc105-proof.test.ts
+++ b/src/brc105-proof.test.ts
@@ -240,14 +240,25 @@ describe("constructBrc105Proof", () => {
     expect(params.options.returnTXIDOnly).toBe(false)
   })
 
-  it("returns abort callback when wallet has abortAction", async () => {
-    const wallet = mockWallet({
-      abortAction: vi.fn().mockResolvedValue({ aborted: true }),
-    })
+  it("returns abort callback that calls wallet.abortAction with txid", async () => {
+    const abortAction = vi.fn().mockResolvedValue({ aborted: true })
+    const wallet = mockWallet({ abortAction })
     const { proof, abort } = await constructBrc105Proof(CHALLENGE, wallet)
 
-    expect(proof).toBeDefined()
     expect(abort).toBeDefined()
+    await abort!()
+    expect(abortAction).toHaveBeenCalledOnce()
+    expect(abortAction).toHaveBeenCalledWith({ reference: proof.txid })
+  })
+
+  it("abort callback swallows errors from wallet.abortAction", async () => {
+    const abortAction = vi.fn().mockRejectedValue(new Error("abort failed"))
+    const wallet = mockWallet({ abortAction })
+    const { abort } = await constructBrc105Proof(CHALLENGE, wallet)
+
+    expect(abort).toBeDefined()
+    // Should not throw
+    await expect(abort!()).resolves.toBeUndefined()
   })
 
   it("returns undefined abort when wallet lacks abortAction", async () => {

--- a/src/brc105-proof.ts
+++ b/src/brc105-proof.ts
@@ -1,4 +1,4 @@
-import type { Brc105Challenge, Brc105Proof, Brc105Wallet } from "./types"
+import type { Brc105Challenge, Brc105ProofResult, Brc105Wallet } from "./types"
 
 // === Byte encoding helpers ===
 
@@ -211,7 +211,7 @@ export async function constructBrc105Proof(
   challenge: Brc105Challenge,
   wallet: Brc105Wallet,
   origin?: string,
-): Promise<Brc105Proof> {
+): Promise<Brc105ProofResult> {
   // Step 1: Get client's identity key (for inclusion in proof)
   const { publicKey: clientIdentityKey } = await wallet.getPublicKey({ identityKey: true })
 
@@ -264,13 +264,25 @@ export async function constructBrc105Proof(
     throw new Error("Wallet returned no transaction data (neither tx nor rawTx)")
   }
 
-  return {
+  const proof = {
     derivationPrefix: challenge.derivationPrefix,
     derivationSuffix,
     transaction: transactionBase64,
     clientIdentityKey,
     txid: result.txid,
   }
+
+  const abort = wallet.abortAction
+    ? async () => {
+        try {
+          await wallet.abortAction!({ reference: result.txid })
+        } catch (err) {
+          console.warn('[x402] abortAction failed:', err)
+        }
+      }
+    : undefined
+
+  return { proof, abort }
 }
 
 // Exported for testing

--- a/src/brc105-proof.ts
+++ b/src/brc105-proof.ts
@@ -247,6 +247,8 @@ export async function constructBrc105Proof(
       }),
     }],
     options: {
+      returnTXIDOnly: false,
+      noSend: true,
       randomizeOutputs: false,
     },
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,12 @@ export interface Brc105Proof {
   txid: string         // from wallet createAction result
 }
 
-export type Brc105ProofConstructor = (challenge: Brc105Challenge) => Promise<Brc105Proof>
+export interface Brc105ProofResult {
+  proof: Brc105Proof
+  abort?: () => Promise<void>
+}
+
+export type Brc105ProofConstructor = (challenge: Brc105Challenge) => Promise<Brc105ProofResult>
 
 // === Protocol-agnostic payment request ===
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface Brc105Wallet {
   ): Promise<{ publicKey: string }>
   createHmac(params: { data: number[]; protocolID: [number, string]; keyID: string; counterparty?: string }): Promise<{ hmac: number[] }>
   createAction(params: CWICreateActionParams): Promise<CWICreateActionResult>
+  abortAction?: (args: { reference: string }) => Promise<{ aborted: boolean }>
 }
 
 export interface Brc105Proof {

--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -496,4 +496,26 @@ describe("createX402Fetch — BRC-105", () => {
 
     expect(res.status).toBe(500)
   })
+
+  it("calls abort when retry fetch throws (network error)", async () => {
+    const abort = vi.fn()
+    const brc105Proof = vi.fn().mockResolvedValue({
+      proof: {
+        derivationPrefix: "prefix",
+        derivationSuffix: "suffix",
+        transaction: "dHg=",
+        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        txid: "abc123",
+      },
+      abort,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    await expect(f("https://api.example.com/data")).rejects.toThrow("Failed to fetch")
+    expect(abort).toHaveBeenCalledOnce()
+  })
 })

--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { createX402Fetch, payeeAddressToLockingScript } from "./x402-fetch"
-import type { Brc105Challenge, Brc105Proof } from "./types"
+import type { Brc105Challenge, Brc105ProofResult } from "./types"
 
 function make402Response(amount: number = 1000) {
   return new Response("Payment Required", {
@@ -289,13 +289,15 @@ function makeBrc105Response(
   })
 }
 
-function mockBrc105ProofConstructor(): (challenge: Brc105Challenge) => Promise<Brc105Proof> {
+function mockBrc105ProofConstructor(): (challenge: Brc105Challenge) => Promise<Brc105ProofResult> {
   return vi.fn(async (challenge: Brc105Challenge) => ({
-    derivationPrefix: challenge.derivationPrefix,
-    derivationSuffix: "mock-suffix",
-    transaction: "bW9jay10eA==", // "mock-tx" in base64
-    clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
-    txid: "brc105-mock-txid",
+    proof: {
+      derivationPrefix: challenge.derivationPrefix,
+      derivationSuffix: "mock-suffix",
+      transaction: "bW9jay10eA==", // "mock-tx" in base64
+      clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      txid: "brc105-mock-txid",
+    },
   }))
 }
 
@@ -424,5 +426,74 @@ describe("createX402Fetch — BRC-105", () => {
     await f("https://api.example.com/data")
     expect(onProofError).toHaveBeenCalledOnce()
     expect(onProofError).toHaveBeenCalledWith(error, "brc105")
+  })
+
+  it("does not call abort when server returns 200", async () => {
+    const abort = vi.fn()
+    const brc105Proof = vi.fn().mockResolvedValue({
+      proof: {
+        derivationPrefix: "prefix",
+        derivationSuffix: "suffix",
+        transaction: "dHg=",
+        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        txid: "abc123",
+      },
+      abort,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(abort).not.toHaveBeenCalled()
+  })
+
+  it("calls abort when server returns 500", async () => {
+    const abort = vi.fn()
+    const brc105Proof = vi.fn().mockResolvedValue({
+      proof: {
+        derivationPrefix: "prefix",
+        derivationSuffix: "suffix",
+        transaction: "dHg=",
+        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        txid: "abc123",
+      },
+      abort,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(500)
+    expect(abort).toHaveBeenCalledOnce()
+  })
+
+  it("handles missing abort gracefully on server failure", async () => {
+    const brc105Proof = vi.fn().mockResolvedValue({
+      proof: {
+        derivationPrefix: "prefix",
+        derivationSuffix: "suffix",
+        transaction: "dHg=",
+        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        txid: "abc123",
+      },
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(500)
   })
 })

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -211,7 +211,18 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
       const headers = new Headers(init?.headers)
       headers.set("x-bsv-payment", JSON.stringify(proof))
       headers.set("x-bsv-auth-identity-key", proof.clientIdentityKey)
-      const retryResponse = await fetch(input, { ...init, headers })
+
+      let retryResponse: Response
+      try {
+        retryResponse = await fetch(input, { ...init, headers })
+      } catch (err) {
+        // Network error, timeout, etc. — abort to release locked UTXOs
+        if (abort) {
+          await abort()
+          console.warn('[x402] BRC-105 retry fetch failed, UTXOs released via abortAction')
+        }
+        throw err
+      }
 
       if (!retryResponse.ok && abort) {
         await abort()

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -191,11 +191,16 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
       }
 
       let proof: import("./types").Brc105Proof
+      let abort: (() => Promise<void>) | undefined
       try {
         if (brc105ProofConstructor) {
-          proof = await brc105ProofConstructor(brc105Challenge)
+          const result = await brc105ProofConstructor(brc105Challenge)
+          proof = result.proof
+          abort = result.abort
         } else {
-          proof = await constructBrc105Proof(brc105Challenge, brc105Wallet!, origin)
+          const result = await constructBrc105Proof(brc105Challenge, brc105Wallet!, origin)
+          proof = result.proof
+          abort = result.abort
         }
       } catch (err) {
         console.error("[x402] Proof construction failed (brc105):", err)
@@ -206,7 +211,14 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
       const headers = new Headers(init?.headers)
       headers.set("x-bsv-payment", JSON.stringify(proof))
       headers.set("x-bsv-auth-identity-key", proof.clientIdentityKey)
-      return fetch(input, { ...init, headers })
+      const retryResponse = await fetch(input, { ...init, headers })
+
+      if (!retryResponse.ok && abort) {
+        await abort()
+        console.warn('[x402] Server rejected BRC-105 payment, UTXOs released via abortAction')
+      }
+
+      return retryResponse
     }
 
     // Neither protocol header present — pass through


### PR DESCRIPTION
## Summary

- **`createAction({ noSend: true })`** — sign tx without broadcasting, preventing phantom UTXOs when server rejects
- **`abortAction` on server failure** — releases locked UTXOs back to spendable pool when server returns non-200
- **`Brc105ProofResult`** — proof constructor returns `{ proof, abort? }`, keeping wallet encapsulated via closure
- **`Brc105Wallet.abortAction?`** — optional method added to wallet interface (accepts txid as reference)
- **6 new tests** covering abort-on-failure, no-abort-on-success, and graceful skip when wallet lacks abortAction

### How it works

1. Client signs tx (`noSend: true`) → gets BEEF without broadcasting
2. Sends BEEF to server via `x-bsv-payment` header
3. Server 200 → done (server's subsequent spends implicitly broadcast via BEEF ancestry chaining)
4. Server error → `abort()` callback releases UTXOs, no phantom change outputs

## Test plan
- [x] All 185 tests pass
- [x] TypeScript compiles cleanly (main + plugins)
- [x] Custom X402 path unaffected
- [x] Server 200 → no abort
- [x] Server 500 → abort called
- [x] Wallet without abortAction → graceful skip

Closes #103
