### PR TITLE
feat: autospend balance increases on internalised refunds

### DIFF
--- a/plugins/shared/cwi-proxy.ts
+++ b/plugins/shared/cwi-proxy.ts
@@ -97,11 +97,14 @@ export async function handleCWIRequest(
         if (params?.tx && params?.outputs) {
           const tx = Transaction.fromAtomicBEEF(params.tx)
 
+          const seen = new Set<number>()
           let refundSats = 0
           for (const o of params.outputs) {
-            if (o.protocol === 'wallet payment') {
+            if (o.protocol === 'wallet payment' && !seen.has(o.outputIndex)) {
+              seen.add(o.outputIndex)
               const output = tx.outputs[o.outputIndex]
               if (output?.satoshis != null) {
+                if (!Number.isSafeInteger(refundSats + output.satoshis)) break
                 refundSats += output.satoshis
               } else {
                 console.warn(`[x402] internalizeAction: outputIndex ${o.outputIndex} out of range, skipping`)

--- a/plugins/shared/cwi-proxy.ts
+++ b/plugins/shared/cwi-proxy.ts
@@ -1,6 +1,7 @@
 import type { ContentToBackgroundMessage, CWIResponse } from './messages'
 import type { WalletBackend } from './wallet-backend'
-import { checkSpendLimits, recordPayment, getSpendStatus } from './x402-controller'
+import { checkSpendLimits, recordPayment, recordRefund, getSpendStatus } from './x402-controller'
+import { Transaction } from '@bsv/sdk'
 import { requestApproval } from './pending-approvals'
 import type { PaymentRequest } from '../../src/types'
 
@@ -82,6 +83,45 @@ export async function handleCWIRequest(
             void chrome.runtime?.lastError
           })
         }
+      }
+    }
+
+    // Record refund on successful internalizeAction — parse BEEF for wallet payment outputs
+    if (request.method === 'internalizeAction' && result != null) {
+      try {
+        const params = request.params as {
+          tx: number[]
+          outputs: Array<{ outputIndex: number; protocol: string }>
+        } | undefined
+
+        if (params?.tx && params?.outputs) {
+          const tx = Transaction.fromAtomicBEEF(params.tx)
+
+          let refundSats = 0
+          for (const o of params.outputs) {
+            if (o.protocol === 'wallet payment') {
+              const output = tx.outputs[o.outputIndex]
+              if (output?.satoshis != null) {
+                refundSats += output.satoshis
+              } else {
+                console.warn(`[x402] internalizeAction: outputIndex ${o.outputIndex} out of range, skipping`)
+              }
+            }
+          }
+
+          if (refundSats > 0) {
+            recordRefund(refundSats, Infinity)
+
+            if (senderTabId !== undefined) {
+              const status = getSpendStatus()
+              chrome.tabs.sendMessage(senderTabId, { type: 'spendUpdated', status }, () => {
+                void chrome.runtime?.lastError
+              })
+            }
+          }
+        }
+      } catch (err) {
+        console.warn('[x402] Failed to parse internalizeAction BEEF for refund recording:', err)
       }
     }
 

--- a/plugins/shared/x402-controller.ts
+++ b/plugins/shared/x402-controller.ts
@@ -5,6 +5,7 @@ import {
   WEAPON_CAPS,
   checkPayment,
   recordPayment as recordPaymentFn,
+  recordRefund as recordRefundFn,
   applyPickup as applyPickupFn,
   clampBalanceToTier as clampFn,
   initialState,
@@ -53,6 +54,11 @@ export function checkSpendLimits(request: PaymentRequest): SpendCheckResult {
 /** Deduct a completed payment from the autospend balance. */
 export function recordPayment(amount: number): void {
   state = recordPaymentFn(amount, state)
+}
+
+/** Record a refund — increases autospend balance, capped at tier cap and wallet balance. */
+export function recordRefund(amount: number, walletBalance: number): void {
+  state = recordRefundFn(amount, state, config, walletBalance)
 }
 
 /** Apply a pickup. Caller supplies the current wallet balance for the cap. */

--- a/src/autospend.test.ts
+++ b/src/autospend.test.ts
@@ -236,3 +236,51 @@ describe("initialState", () => {
     expect(state.balance).toBe(50_000_000)
   })
 })
+
+describe("spend/refund cycle integration", () => {
+  it("spend then partial refund yields correct net spend", () => {
+    const config: AutospendConfig = { tier: "Hurt Me Plenty", weapon: "Pistol" }
+    const walletBalance = 10_000_000_000
+    let state = initialState(config, walletBalance) // 100_000_000
+
+    state = recordPayment(50_000, state) // 99_950_000
+    expect(state.balance).toBe(99_950_000)
+
+    state = recordRefund(30_000, state, config, walletBalance) // 99_980_000
+    expect(state.balance).toBe(99_980_000)
+  })
+
+  it("refund exceeding original spend is capped at tier cap", () => {
+    const config: AutospendConfig = { tier: "Hurt Me Plenty", weapon: "Pistol" }
+    const walletBalance = 10_000_000_000
+    let state = initialState(config, walletBalance) // 100_000_000
+
+    state = recordPayment(50_000, state) // 99_950_000
+    state = recordRefund(100_000, state, config, walletBalance) // capped at 100_000_000
+    expect(state.balance).toBe(100_000_000)
+  })
+
+  it("multiple spend/refund cycles yield correct net balance", () => {
+    const config: AutospendConfig = { tier: "Hurt Me Plenty", weapon: "Pistol" }
+    const walletBalance = 10_000_000_000
+    let state = initialState(config, walletBalance) // 100_000_000
+
+    state = recordPayment(10_000, state)   // 99_990_000
+    state = recordPayment(20_000, state)   // 99_970_000
+    state = recordRefund(15_000, state, config, walletBalance) // 99_985_000
+    state = recordPayment(5_000, state)    // 99_980_000
+    state = recordRefund(10_000, state, config, walletBalance) // 99_990_000
+    // net: -10k -20k +15k -5k +10k = -10k
+    expect(state.balance).toBe(99_990_000)
+  })
+
+  it("wallet balance constrains refund during cycle", () => {
+    const config: AutospendConfig = { tier: "Hurt Me Plenty", weapon: "Pistol" }
+    const walletBalance = 50_000_000 // below tier cap of 100M
+    let state = initialState(config, walletBalance) // 50_000_000
+
+    state = recordPayment(10_000, state) // 49_990_000
+    state = recordRefund(20_000, state, config, walletBalance) // capped at 50_000_000
+    expect(state.balance).toBe(50_000_000)
+  })
+})

--- a/src/autospend.test.ts
+++ b/src/autospend.test.ts
@@ -5,6 +5,7 @@ import {
   PICKUP_PERCENTAGES,
   checkPayment,
   recordPayment,
+  recordRefund,
   applyPickup,
   clampBalanceToTier,
   initialState,
@@ -92,6 +93,62 @@ describe("recordPayment", () => {
     expect(recordPayment(NaN, state)).toEqual({ balance: 1_000_000 })
     expect(recordPayment(Infinity, state)).toEqual({ balance: 1_000_000 })
     expect(recordPayment(0, state)).toEqual({ balance: 1_000_000 })
+  })
+})
+
+describe("recordRefund", () => {
+  const walletBalance = 10_000_000_000
+
+  it("increases balance by the refund amount", () => {
+    const state: AutospendState = { balance: 50_000_000 }
+    const result = recordRefund(10_000_000, state, HMP, walletBalance)
+    expect(result.balance).toBe(60_000_000)
+  })
+
+  it("caps refund at tier cap", () => {
+    const state: AutospendState = { balance: 95_000_000 }
+    const result = recordRefund(20_000_000, state, HMP, walletBalance)
+    expect(result.balance).toBe(100_000_000) // HMP tier cap, not 115M
+  })
+
+  it("caps refund at wallet balance when wallet balance < tier cap", () => {
+    const state: AutospendState = { balance: 40_000_000 }
+    const result = recordRefund(20_000_000, state, HMP, 50_000_000)
+    expect(result.balance).toBe(50_000_000) // wallet balance cap, not 60M
+  })
+
+  it("returns state unchanged for invalid amounts", () => {
+    const state: AutospendState = { balance: 50_000_000 }
+    expect(recordRefund(NaN, state, HMP, walletBalance)).toBe(state)
+    expect(recordRefund(Infinity, state, HMP, walletBalance)).toBe(state)
+    expect(recordRefund(-100, state, HMP, walletBalance)).toBe(state)
+    expect(recordRefund(0, state, HMP, walletBalance)).toBe(state)
+  })
+
+  it("refund after spend restores balance correctly", () => {
+    const config: AutospendConfig = { tier: "Hurt Me Plenty", weapon: "Pistol" }
+    let state = initialState(config, walletBalance) // 100_000_000
+    state = recordPayment(30_000_000, state) // 70_000_000
+    state = recordRefund(15_000_000, state, config, walletBalance) // 85_000_000
+    expect(state.balance).toBe(85_000_000)
+  })
+
+  it("refund at full balance is a no-op", () => {
+    const state: AutospendState = { balance: 100_000_000 } // at HMP tier cap
+    const result = recordRefund(10_000_000, state, HMP, walletBalance)
+    expect(result.balance).toBe(100_000_000)
+  })
+
+  it("refund after full depletion restores balance to refund amount", () => {
+    const state: AutospendState = { balance: 0 }
+    const result = recordRefund(25_000_000, state, HMP, walletBalance)
+    expect(result.balance).toBe(25_000_000)
+  })
+
+  it("does not mutate the input state", () => {
+    const state: AutospendState = { balance: 50_000_000 }
+    recordRefund(10_000_000, state, HMP, walletBalance)
+    expect(state.balance).toBe(50_000_000)
   })
 })
 

--- a/src/autospend.ts
+++ b/src/autospend.ts
@@ -117,6 +117,21 @@ export function clampBalanceToTier(
 }
 
 /**
+ * Record a refund — increases the autospend balance by the refund amount,
+ * capped at min(tierCap, walletBalance). Invalid amounts are ignored.
+ */
+export function recordRefund(
+  amount: number,
+  state: AutospendState,
+  config: AutospendConfig,
+  walletBalance: number,
+): AutospendState {
+  if (!isValidAmount(amount)) return state
+  const cap = Math.min(TIER_CAPS[config.tier], walletBalance)
+  return { balance: Math.min(cap, state.balance + amount) }
+}
+
+/**
  * Create a fresh autospend state at the tier cap.
  */
 export function initialState(config: AutospendConfig, walletBalance: number): AutospendState {


### PR DESCRIPTION
## Summary

- **`recordRefund`** pure function in autospend module -- increments balance, capped at `min(tierCap, walletBalance)`
- **x402 controller wrapper** -- `recordRefund(amount, walletBalance)` mirrors existing `recordPayment`
- **CWI proxy intercept** -- after successful `internalizeAction`, parses BEEF to extract `wallet payment` output satoshis and records the refund. Non-fatal on parse failure.
- **12 new tests** -- unit tests for recordRefund (8) + integration tests for spend/refund cycles (4)

### How it works

When a server sends a refund (e.g. Doom health pickup), the client calls `internalizeAction` via CWI. The proxy intercepts the successful result, parses the AtomicBEEF to sum wallet payment outputs, and increments the autospend balance. The autospend counter now tracks net spend (gross spend minus refunds), preventing unnecessary confirmation popups during gameplay.

## Test plan
- [x] All 204 tests pass
- [x] TypeScript compiles cleanly (main + plugins)
- [x] Refund increases autospend balance
- [x] Refund capped at tier cap and wallet balance
- [x] Spend/refund cycle produces correct net balance
- [x] Existing createAction/pickup flows unaffected
- [x] BEEF parse failure doesn't block wallet operations

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
