### PR TITLE
feat: three-state retry for BRC-105 payments (#103)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,8 @@ export interface X402Config {
   brc105ProofConstructor?: Brc105ProofConstructor
   brc105Wallet?: Brc105Wallet
   onProofError?: (error: unknown, protocol: PaymentProtocol) => void
+  /** Maximum number of retries for network errors during BRC-105 payment (default: 2). */
+  maxRetries?: number
 }
 
 // === BRC-100 CWI interface types ===

--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -485,7 +485,66 @@ describe("createX402Fetch — BRC-105", () => {
     expect(abort).not.toHaveBeenCalled()
   })
 
-  it("calls abort when server returns 500", async () => {
+  it("calls abort and retries with fresh proof when server returns 500", async () => {
+    const abort = vi.fn()
+    const freshAbort = vi.fn()
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: callCount === 1 ? "original-suffix" : "fresh-suffix",
+          transaction: callCount === 1 ? "b3JpZ2luYWw=" : "ZnJlc2g=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: callCount === 1 ? "original-txid" : "fresh-txid",
+        },
+        abort: callCount === 1 ? abort : freshAbort,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(abort).toHaveBeenCalledOnce()
+    expect(freshAbort).not.toHaveBeenCalled()
+    expect(brc105Proof).toHaveBeenCalledTimes(2)
+  })
+
+  it("handles missing abort gracefully on server rejection with fresh retry", async () => {
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: "suffix-" + callCount,
+          transaction: "dHg=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: "txid-" + callCount,
+        },
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(brc105Proof).toHaveBeenCalledTimes(2)
+  })
+
+  it("throws unknown payment state when all network retries exhausted", async () => {
     const abort = vi.fn()
     const brc105Proof = vi.fn().mockResolvedValue({
       proof: {
@@ -500,37 +559,14 @@ describe("createX402Fetch — BRC-105", () => {
 
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce(makeBrc105Response(1000))
-      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockRejectedValue(new TypeError("Failed to fetch"))
 
-    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
-    const res = await f("https://api.example.com/data")
-
-    expect(res.status).toBe(500)
-    expect(abort).toHaveBeenCalledOnce()
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof, maxRetries: 0 })
+    await expect(f("https://api.example.com/data")).rejects.toThrow("Payment state unknown")
+    expect(abort).not.toHaveBeenCalled()
   })
 
-  it("handles missing abort gracefully on server failure", async () => {
-    const brc105Proof = vi.fn().mockResolvedValue({
-      proof: {
-        derivationPrefix: "prefix",
-        derivationSuffix: "suffix",
-        transaction: "dHg=",
-        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
-        txid: "abc123",
-      },
-    })
-
-    globalThis.fetch = vi.fn()
-      .mockResolvedValueOnce(makeBrc105Response(1000))
-      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
-
-    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
-    const res = await f("https://api.example.com/data")
-
-    expect(res.status).toBe(500)
-  })
-
-  it("calls abort when retry fetch throws (network error)", async () => {
+  it("retries same proof on network error then succeeds on 200", async () => {
     const abort = vi.fn()
     const brc105Proof = vi.fn().mockResolvedValue({
       proof: {
@@ -546,9 +582,227 @@ describe("createX402Fetch — BRC-105", () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce(makeBrc105Response(1000))
       .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof, maxRetries: 1 })
+
+    vi.useFakeTimers()
+    const promise = f("https://api.example.com/data")
+    await vi.advanceTimersByTimeAsync(1000)
+    const res = await promise
+    vi.useRealTimers()
+
+    expect(res.status).toBe(200)
+    expect(abort).not.toHaveBeenCalled()
+    expect(brc105Proof).toHaveBeenCalledOnce()
+
+    // Same x-bsv-payment header reused on both attempts
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    const firstRetryHeaders = (fetchMock.mock.calls[1][1]?.headers as Headers).get("x-bsv-payment")
+    const secondRetryHeaders = (fetchMock.mock.calls[2][1]?.headers as Headers).get("x-bsv-payment")
+    expect(firstRetryHeaders).toBe(secondRetryHeaders)
+  })
+
+  it("retries same proof on network error then aborts + fresh retries on 500", async () => {
+    const abort = vi.fn()
+    const freshAbort = vi.fn()
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: callCount === 1 ? "original" : "fresh",
+          transaction: callCount === 1 ? "b3JpZw==" : "ZnJlc2g=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: callCount === 1 ? "original-txid" : "fresh-txid",
+        },
+        abort: callCount === 1 ? abort : freshAbort,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof, maxRetries: 1 })
+
+    vi.useFakeTimers()
+    const promise = f("https://api.example.com/data")
+    await vi.advanceTimersByTimeAsync(1000)
+    const res = await promise
+    vi.useRealTimers()
+
+    expect(res.status).toBe(200)
+    // Original proof aborted after 500, fresh proof used for final attempt
+    expect(abort).toHaveBeenCalledOnce()
+    expect(freshAbort).not.toHaveBeenCalled()
+    expect(brc105Proof).toHaveBeenCalledTimes(2)
+  })
+
+  it("reuses same x-bsv-payment header across network retries", async () => {
+    const brc105Proof = vi.fn().mockResolvedValue({
+      proof: {
+        derivationPrefix: "prefix",
+        derivationSuffix: "suffix",
+        transaction: "dHg=",
+        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        txid: "abc123",
+      },
+    })
+
+    // Use maxRetries: 0 — single attempt, no delay needed, no timer issues
+    // The "retries same proof on network error then succeeds" test already
+    // proves retry uses the same proof; this test focuses on header identity
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof, maxRetries: 1 })
+
+    vi.useFakeTimers()
+    const promise = f("https://api.example.com/data")
+    await vi.runAllTimersAsync()
+    const res = await promise
+    vi.useRealTimers()
+
+    expect(res.status).toBe(200)
+
+    // Proof constructor called once — same proof reused across retries
+    expect(brc105Proof).toHaveBeenCalledOnce()
+
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    const header1 = (fetchMock.mock.calls[1][1]?.headers as Headers).get("x-bsv-payment")
+    const header2 = (fetchMock.mock.calls[2][1]?.headers as Headers).get("x-bsv-payment")
+    expect(header1).toBe(header2)
+  })
+
+  it("uses different proof on fresh retry after server rejection", async () => {
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: "suffix-" + callCount,
+          transaction: callCount === 1 ? "b3JpZ2luYWw=" : "ZnJlc2g=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: "txid-" + callCount,
+        },
+        abort: vi.fn(),
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockResolvedValueOnce(make200Response())
 
     const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
-    await expect(f("https://api.example.com/data")).rejects.toThrow("Failed to fetch")
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    const originalPayment = (fetchMock.mock.calls[1][1]?.headers as Headers).get("x-bsv-payment")
+    const freshPayment = (fetchMock.mock.calls[2][1]?.headers as Headers).get("x-bsv-payment")
+    expect(originalPayment).not.toBe(freshPayment)
+
+    const original = JSON.parse(originalPayment!)
+    const fresh = JSON.parse(freshPayment!)
+    expect(original.transaction).toBe("b3JpZ2luYWw=")
+    expect(fresh.transaction).toBe("ZnJlc2g=")
+  })
+
+  it("returns error response when server rejects twice (double rejection)", async () => {
+    const abort1 = vi.fn()
+    const abort2 = vi.fn()
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: "suffix-" + callCount,
+          transaction: "dHg=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: "txid-" + callCount,
+        },
+        abort: callCount === 1 ? abort1 : abort2,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Bad Request", { status: 400 }))
+      .mockResolvedValueOnce(new Response("Bad Request Again", { status: 400 }))
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(400)
+    expect(abort1).toHaveBeenCalledOnce()
+    expect(abort2).toHaveBeenCalledOnce()
+    expect(brc105Proof).toHaveBeenCalledTimes(2)
+  })
+
+  it("throws unknown state when fresh retry gets network error after server rejection", async () => {
+    const abort = vi.fn()
+    const freshAbort = vi.fn()
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: "suffix-" + callCount,
+          transaction: "dHg=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: "txid-" + callCount,
+        },
+        abort: callCount === 1 ? abort : freshAbort,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    await expect(f("https://api.example.com/data")).rejects.toThrow("Payment state unknown")
+
+    // First proof aborted after server rejection
     expect(abort).toHaveBeenCalledOnce()
+    // Fresh proof NOT aborted (tx may be on-chain)
+    expect(freshAbort).not.toHaveBeenCalled()
+  })
+
+  it("propagates original error when abort() throws during server rejection", async () => {
+    const abort = vi.fn().mockRejectedValue(new Error("abort failed"))
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: "suffix-" + callCount,
+          transaction: "dHg=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: "txid-" + callCount,
+        },
+        abort,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    await expect(f("https://api.example.com/data")).rejects.toThrow("abort failed")
   })
 })

--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -781,7 +781,7 @@ describe("createX402Fetch — BRC-105", () => {
     expect(freshAbort).not.toHaveBeenCalled()
   })
 
-  it("propagates original error when abort() throws during server rejection", async () => {
+  it("swallows abort error and still performs fresh retry", async () => {
     const abort = vi.fn().mockRejectedValue(new Error("abort failed"))
     let callCount = 0
     const brc105Proof = vi.fn().mockImplementation(async () => {
@@ -790,7 +790,7 @@ describe("createX402Fetch — BRC-105", () => {
         proof: {
           derivationPrefix: "prefix",
           derivationSuffix: "suffix-" + callCount,
-          transaction: "dHg=",
+          transaction: callCount === 1 ? "b3JpZw==" : "ZnJlc2g=",
           clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
           txid: "txid-" + callCount,
         },
@@ -801,8 +801,13 @@ describe("createX402Fetch — BRC-105", () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce(makeBrc105Response(1000))
       .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockResolvedValueOnce(make200Response())
 
     const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
-    await expect(f("https://api.example.com/data")).rejects.toThrow("abort failed")
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(abort).toHaveBeenCalledOnce()
+    expect(brc105Proof).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -174,6 +174,7 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
   const constructProof = config.proofConstructor ?? defaultConstructProof
   const brc105ProofConstructor = config.brc105ProofConstructor
   const brc105Wallet = config.brc105Wallet
+  const maxRetries = config.maxRetries ?? 2
 
   return async function x402Fetch(
     input: RequestInfo | URL,
@@ -224,46 +225,98 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
         return response
       }
 
+      // Helper: build proof using whichever constructor is configured
+      const buildProof = async () => {
+        if (brc105ProofConstructor) {
+          return brc105ProofConstructor(brc105Challenge)
+        }
+        return constructBrc105Proof(brc105Challenge, brc105Wallet!, origin)
+      }
+
+      // Helper: build headers from a proof
+      const proofHeaders = (proof: import("./types").Brc105Proof) => {
+        const h = new Headers(init?.headers)
+        h.set("x-bsv-payment", JSON.stringify(proof))
+        h.set("x-bsv-auth-identity-key", proof.clientIdentityKey)
+        return h
+      }
+
       let proof: import("./types").Brc105Proof
       let abort: (() => Promise<void>) | undefined
       try {
-        if (brc105ProofConstructor) {
-          const result = await brc105ProofConstructor(brc105Challenge)
-          proof = result.proof
-          abort = result.abort
-        } else {
-          const result = await constructBrc105Proof(brc105Challenge, brc105Wallet!, origin)
-          proof = result.proof
-          abort = result.abort
-        }
+        const result = await buildProof()
+        proof = result.proof
+        abort = result.abort
       } catch (err) {
         console.error("[x402] Proof construction failed (brc105):", err)
         config.onProofError?.(err, "brc105")
         return response
       }
 
-      const headers = new Headers(init?.headers)
-      headers.set("x-bsv-payment", JSON.stringify(proof))
-      headers.set("x-bsv-auth-identity-key", proof.clientIdentityKey)
-
-      let retryResponse: Response
-      try {
-        retryResponse = await fetch(input, { ...init, headers })
-      } catch (err) {
-        // Network error, timeout, etc. — abort to release locked UTXOs
-        if (abort) {
-          await abort()
-          console.warn('[x402] BRC-105 retry fetch failed, UTXOs released via abortAction')
+      // --- Network retry loop: resend the same signed tx ---
+      let retryResponse: Response | undefined
+      let networkError = false
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        if (attempt > 0) {
+          await delay(1000 * 2 ** (attempt - 1))
         }
-        throw err
+        try {
+          retryResponse = await fetch(input, { ...init, headers: proofHeaders(proof) })
+          networkError = false
+          break
+        } catch {
+          networkError = true
+        }
       }
 
-      if (!retryResponse.ok && abort) {
+      // Network error: all retries exhausted — do NOT abort (tx may be on-chain)
+      if (networkError) {
+        throw new Error(
+          "[x402] Payment state unknown: network error after " +
+          `${maxRetries + 1} attempts. The transaction may have been broadcast — ` +
+          "do not retry with a new transaction without checking on-chain state.",
+        )
+      }
+
+      // Success
+      if (retryResponse!.ok) return retryResponse!
+
+      // --- Server rejection: abort, then single fresh retry ---
+      if (abort) {
         await abort()
         console.warn('[x402] Server rejected BRC-105 payment, UTXOs released via abortAction')
       }
 
-      return retryResponse
+      let freshProof: import("./types").Brc105Proof
+      let freshAbort: (() => Promise<void>) | undefined
+      try {
+        const result = await buildProof()
+        freshProof = result.proof
+        freshAbort = result.abort
+      } catch (err) {
+        console.error("[x402] Fresh proof construction failed (brc105):", err)
+        config.onProofError?.(err, "brc105")
+        return retryResponse!
+      }
+
+      let freshResponse: Response
+      try {
+        freshResponse = await fetch(input, { ...init, headers: proofHeaders(freshProof) })
+      } catch {
+        // Network error on fresh attempt — do NOT abort (tx may be on-chain)
+        throw new Error(
+          "[x402] Payment state unknown: network error on fresh retry. " +
+          "The transaction may have been broadcast — " +
+          "do not retry with a new transaction without checking on-chain state.",
+        )
+      }
+
+      if (!freshResponse.ok && freshAbort) {
+        await freshAbort()
+        console.warn('[x402] Server rejected fresh BRC-105 payment, UTXOs released via abortAction')
+      }
+
+      return freshResponse
     }
 
     // Neither protocol header present — pass through
@@ -284,6 +337,10 @@ export async function x402Fetch(
 }
 
 // === Helpers ===
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 function resolveRelativeUrl(url: string): string {
   const loc = (globalThis as typeof globalThis & { location?: { href?: string } }).location

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -283,8 +283,12 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
 
       // --- Server rejection: abort, then single fresh retry ---
       if (abort) {
-        await abort()
-        console.warn('[x402] Server rejected BRC-105 payment, UTXOs released via abortAction')
+        try {
+          await abort()
+          console.warn('[x402] Server rejected BRC-105 payment, UTXOs released via abortAction')
+        } catch (err) {
+          console.warn('[x402] abortAction failed during server rejection:', err)
+        }
       }
 
       let freshProof: import("./types").Brc105Proof
@@ -312,8 +316,12 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
       }
 
       if (!freshResponse.ok && freshAbort) {
-        await freshAbort()
-        console.warn('[x402] Server rejected fresh BRC-105 payment, UTXOs released via abortAction')
+        try {
+          await freshAbort()
+          console.warn('[x402] Server rejected fresh BRC-105 payment, UTXOs released via abortAction')
+        } catch (err) {
+          console.warn('[x402] freshAbort failed during double rejection:', err)
+        }
       }
 
       return freshResponse


### PR DESCRIPTION
## Summary
- Split BRC-105 retry path into three distinct outcomes: success (return), network error (retry same tx), server rejection (abort + fresh retry)
- Network errors retry the same signed tx with exponential backoff — never abort, since the server may have already broadcast
- Server rejections abort UTXOs and retry once with a fresh `createAction` — if second attempt also fails, abort and return error
- Max retries exhausted without server response throws with unknown payment state (no abort)
- Added `maxRetries` config option to `X402Config` (default: 2)
- 8 new tests covering all three states, edge cases, and proof identity verification

## Test plan
- [x] All 211 tests pass
- [x] Build clean (ESM + CJS + DTS)
- [x] Typecheck clean
- [x] Acceptance criteria for #123 and #125 verified

Closes #103
