### PR TITLE
feat: support BRC-121 Simple 402 Payments (#138)

### DIFF
--- a/src/brc121-challenge.test.ts
+++ b/src/brc121-challenge.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import { parseBrc121Challenge } from "./brc121-challenge"
+
+function makeResponse(headers: Record<string, string>): Response {
+  return new Response(null, { status: 402, headers })
+}
+
+const VALID_KEY = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+const VALID_HEADERS = {
+  "x-bsv-sats": "100",
+  "x-bsv-server": VALID_KEY,
+}
+
+describe("parseBrc121Challenge", () => {
+  it("parses valid headers", () => {
+    const c = parseBrc121Challenge(makeResponse(VALID_HEADERS))
+    expect(c).not.toBeNull()
+    expect(c!.satoshis).toBe(100)
+    expect(c!.serverIdentityKey).toBe(VALID_KEY)
+  })
+
+  it("returns null when x-bsv-sats is missing", () => {
+    const { "x-bsv-sats": _, ...rest } = VALID_HEADERS
+    expect(parseBrc121Challenge(makeResponse(rest))).toBeNull()
+  })
+
+  it("returns null when x-bsv-server is missing", () => {
+    const { "x-bsv-server": _, ...rest } = VALID_HEADERS
+    expect(parseBrc121Challenge(makeResponse(rest))).toBeNull()
+  })
+
+  it("returns null when x-bsv-payment-version is present (BRC-105 discrimination)", () => {
+    expect(parseBrc121Challenge(makeResponse({
+      ...VALID_HEADERS,
+      "x-bsv-payment-version": "1.0",
+    }))).toBeNull()
+  })
+
+  it("rejects x-bsv-sats of 0", () => {
+    expect(() => parseBrc121Challenge(makeResponse({
+      ...VALID_HEADERS,
+      "x-bsv-sats": "0",
+    }))).toThrow("positive integer")
+  })
+
+  it("rejects negative x-bsv-sats", () => {
+    expect(() => parseBrc121Challenge(makeResponse({
+      ...VALID_HEADERS,
+      "x-bsv-sats": "-1",
+    }))).toThrow("positive integer")
+  })
+
+  it("rejects fractional x-bsv-sats", () => {
+    expect(() => parseBrc121Challenge(makeResponse({
+      ...VALID_HEADERS,
+      "x-bsv-sats": "1.5",
+    }))).toThrow("positive integer")
+  })
+
+  it("rejects non-numeric x-bsv-sats", () => {
+    expect(() => parseBrc121Challenge(makeResponse({
+      ...VALID_HEADERS,
+      "x-bsv-sats": "abc",
+    }))).toThrow("positive integer")
+  })
+
+  it("rejects x-bsv-server with wrong length", () => {
+    expect(() => parseBrc121Challenge(makeResponse({
+      ...VALID_HEADERS,
+      "x-bsv-server": "02abc123",
+    }))).toThrow("compressed public key")
+  })
+
+  it("rejects x-bsv-server with wrong prefix (uncompressed key)", () => {
+    expect(() => parseBrc121Challenge(makeResponse({
+      ...VALID_HEADERS,
+      "x-bsv-server": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+    }))).toThrow("compressed public key")
+  })
+
+  it("accepts key with 03 prefix", () => {
+    const key03 = "0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    const c = parseBrc121Challenge(makeResponse({
+      ...VALID_HEADERS,
+      "x-bsv-server": key03,
+    }))
+    expect(c).not.toBeNull()
+    expect(c!.serverIdentityKey).toBe(key03)
+  })
+})

--- a/src/brc121-challenge.ts
+++ b/src/brc121-challenge.ts
@@ -1,0 +1,39 @@
+import type { Brc121Challenge } from "./types"
+
+/**
+ * Parses BRC-121 challenge headers from a 402 response.
+ *
+ * Returns `null` when the required headers are absent or when
+ * `x-bsv-payment-version` is present (indicating BRC-105, not BRC-121).
+ *
+ * Throws on malformed values once the headers are confirmed present,
+ * matching the validation pattern of `parseBrc105Challenge`.
+ */
+export function parseBrc121Challenge(response: Response): Brc121Challenge | null {
+  // BRC-105 discrimination: if x-bsv-payment-version is present, this is BRC-105
+  if (response.headers.get("x-bsv-payment-version") !== null) {
+    return null
+  }
+
+  const satsHeader = response.headers.get("x-bsv-sats")
+  const serverHeader = response.headers.get("x-bsv-server")
+
+  if (!satsHeader || !serverHeader) {
+    return null
+  }
+
+  const satoshis = Number(satsHeader)
+  if (
+    !Number.isFinite(satoshis) ||
+    !Number.isInteger(satoshis) ||
+    satoshis <= 0
+  ) {
+    throw new Error(`BRC-121: x-bsv-sats must be a positive integer, got "${satsHeader}"`)
+  }
+
+  if (!/^0[23][0-9a-fA-F]{64}$/.test(serverHeader)) {
+    throw new Error("BRC-121: x-bsv-server must be a 33-byte compressed public key (hex)")
+  }
+
+  return { satoshis, serverIdentityKey: serverHeader }
+}

--- a/src/brc121-proof.test.ts
+++ b/src/brc121-proof.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest"
+import { constructBrc121Proof } from "./brc121-proof"
+import type { Brc121Challenge, Brc105Wallet } from "./types"
+
+// === Test fixtures ===
+
+const CHALLENGE: Brc121Challenge = {
+  satoshis: 1000,
+  serverIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+}
+
+const TEST_PUBKEY_HEX = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+function mockWallet(overrides: Partial<Brc105Wallet> = {}): Brc105Wallet {
+  return {
+    getPublicKey: vi.fn().mockResolvedValue({
+      publicKey: TEST_PUBKEY_HEX,
+    }),
+    createHmac: vi.fn().mockResolvedValue({
+      hmac: Array.from({ length: 32 }, () => 0xab),
+    }),
+    createAction: vi.fn().mockResolvedValue({
+      txid: "abc123def456",
+      tx: Array.from({ length: 20 }, (_, i) => i),
+    }),
+    ...overrides,
+  }
+}
+
+// === constructBrc121Proof ===
+
+describe("constructBrc121Proof", () => {
+  it("returns correct proof shape with all 6 fields", async () => {
+    const wallet = mockWallet()
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(proof).toHaveProperty("beef")
+    expect(proof).toHaveProperty("senderIdentityKey")
+    expect(proof).toHaveProperty("nonce")
+    expect(proof).toHaveProperty("time")
+    expect(proof).toHaveProperty("vout")
+    expect(proof).toHaveProperty("txid")
+    expect(typeof proof.beef).toBe("string")
+    expect(typeof proof.senderIdentityKey).toBe("string")
+    expect(typeof proof.nonce).toBe("string")
+    expect(typeof proof.time).toBe("string")
+    expect(typeof proof.vout).toBe("string")
+    expect(typeof proof.txid).toBe("string")
+  })
+
+  it("sets vout to '0'", async () => {
+    const wallet = mockWallet()
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(proof.vout).toBe("0")
+  })
+
+  it("sets time to a valid decimal Unix ms timestamp string", async () => {
+    const before = Date.now()
+    const wallet = mockWallet()
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+    const after = Date.now()
+
+    const parsed = Number(proof.time)
+    expect(Number.isFinite(parsed)).toBe(true)
+    expect(Number.isInteger(parsed)).toBe(true)
+    expect(parsed).toBeGreaterThanOrEqual(before)
+    expect(parsed).toBeLessThanOrEqual(after)
+  })
+
+  it("sets nonce to valid base64 that decodes to 8 bytes", async () => {
+    const wallet = mockWallet()
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    // Should not throw
+    const decoded = atob(proof.nonce)
+    expect(decoded).toHaveLength(8)
+  })
+
+  it("uses derivation suffix that is base64 of the UTF-8 time string", async () => {
+    const wallet = mockWallet()
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    // The suffix used in keyID should be btoa(time)
+    const expectedSuffix = btoa(proof.time)
+    const calls = (wallet.getPublicKey as ReturnType<typeof vi.fn>).mock.calls
+    // Second call is BRC-29 derivation
+    const keyID: string = calls[1][0].keyID
+    const parts = keyID.split(" ")
+    expect(parts[1]).toBe(expectedSuffix)
+  })
+
+  it("calls getPublicKey with identityKey: true for sender key", async () => {
+    const wallet = mockWallet()
+    await constructBrc121Proof(CHALLENGE, wallet)
+
+    const calls = (wallet.getPublicKey as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls).toHaveLength(2)
+    expect(calls[0][0]).toEqual({ identityKey: true })
+  })
+
+  it("calls getPublicKey with BRC-29 protocol for key derivation", async () => {
+    const wallet = mockWallet()
+    await constructBrc121Proof(CHALLENGE, wallet)
+
+    const calls = (wallet.getPublicKey as ReturnType<typeof vi.fn>).mock.calls
+    const derivationCall = calls[1][0]
+    expect(derivationCall.protocolID).toEqual([2, "3241645161d8"])
+    expect(derivationCall.counterparty).toBe(CHALLENGE.serverIdentityKey)
+  })
+
+  it("uses space-separated keyID format: nonce + base64 timestamp", async () => {
+    const wallet = mockWallet()
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    const calls = (wallet.getPublicKey as ReturnType<typeof vi.fn>).mock.calls
+    const derivationCall = calls[1][0]
+    const parts = derivationCall.keyID.split(" ")
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toBe(proof.nonce)
+    expect(parts[1]).toBe(btoa(proof.time))
+  })
+
+  it("calls createAction with correct satoshis, noSend: true, randomizeOutputs: false", async () => {
+    const wallet = mockWallet()
+    await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(wallet.createAction).toHaveBeenCalledOnce()
+    const params = (wallet.createAction as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(params.outputs).toHaveLength(1)
+    expect(params.outputs[0].satoshis).toBe(CHALLENGE.satoshis)
+    expect(params.options.noSend).toBe(true)
+    expect(params.options.randomizeOutputs).toBe(false)
+    expect(params.options.returnTXIDOnly).toBe(false)
+  })
+
+  it("handles tx (number[]) to base64 conversion", async () => {
+    const txBytes = [0xca, 0xfe, 0xba, 0xbe]
+    const wallet = mockWallet({
+      createAction: vi.fn().mockResolvedValue({ txid: "aabb", tx: txBytes }),
+    })
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    const decoded = atob(proof.beef)
+    const bytes = Array.from(decoded).map((c) => c.charCodeAt(0))
+    expect(bytes).toEqual(txBytes)
+  })
+
+  it("handles rawTx (hex string) to base64 conversion", async () => {
+    const wallet = mockWallet({
+      createAction: vi.fn().mockResolvedValue({ txid: "aabb", rawTx: "deadbeef" }),
+    })
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    const decoded = atob(proof.beef)
+    const bytes = Array.from(decoded).map((c) => c.charCodeAt(0))
+    expect(bytes).toEqual([0xde, 0xad, 0xbe, 0xef])
+  })
+
+  it("throws when wallet returns no transaction data", async () => {
+    const wallet = mockWallet({
+      createAction: vi.fn().mockResolvedValue({ txid: "aabb" }),
+    })
+    await expect(constructBrc121Proof(CHALLENGE, wallet)).rejects.toThrow(
+      "Wallet returned no transaction data",
+    )
+  })
+
+  it("returns abort callback when wallet has abortAction", async () => {
+    const abortAction = vi.fn().mockResolvedValue({ aborted: true })
+    const wallet = mockWallet({ abortAction })
+    const { proof, abort } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(abort).toBeDefined()
+    await abort!()
+    expect(abortAction).toHaveBeenCalledOnce()
+    expect(abortAction).toHaveBeenCalledWith({ reference: proof.txid })
+  })
+
+  it("returns undefined abort when wallet lacks abortAction", async () => {
+    const wallet = mockWallet()
+    const { abort } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(abort).toBeUndefined()
+  })
+
+  it("abort callback swallows errors from wallet.abortAction", async () => {
+    const abortAction = vi.fn().mockRejectedValue(new Error("abort failed"))
+    const wallet = mockWallet({ abortAction })
+    const { abort } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(abort).toBeDefined()
+    await expect(abort!()).resolves.toBeUndefined()
+  })
+
+  it("sets senderIdentityKey from wallet identity key", async () => {
+    const wallet = mockWallet()
+    const { proof } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(proof.senderIdentityKey).toBe(TEST_PUBKEY_HEX)
+  })
+
+  it("includes origin in action description when provided", async () => {
+    const wallet = mockWallet()
+    await constructBrc121Proof(CHALLENGE, wallet, "https://api.example.com")
+
+    const params = (wallet.createAction as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(params.description).toBe("Payment for request to https://api.example.com")
+  })
+
+  it("uses generic description when origin is not provided", async () => {
+    const wallet = mockWallet()
+    await constructBrc121Proof(CHALLENGE, wallet)
+
+    const params = (wallet.createAction as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(params.description).toBe("BRC-121 payment")
+  })
+})

--- a/src/brc121-proof.ts
+++ b/src/brc121-proof.ts
@@ -1,0 +1,115 @@
+import type { Brc121Challenge, Brc121ProofResult, Brc105Wallet } from "./types"
+import { pubkeyToP2PKHLockingScript } from "./brc105-proof"
+
+// === Byte encoding helpers ===
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ""
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary)
+}
+
+function numberArrayToBase64(arr: number[]): string {
+  return bytesToBase64(new Uint8Array(arr))
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error("Hex string must have even length")
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16)
+  }
+  return bytes
+}
+
+// === Main proof constructor ===
+
+/**
+ * Construct a BRC-121 payment proof from a challenge using BRC-29 key derivation.
+ *
+ * Algorithm (matching @bsv/402-pay reference):
+ * 1. Get client's identity key
+ * 2. Generate nonce (derivation prefix): 8 random bytes → base64
+ * 3. Generate derivation suffix: btoa(Date.now().toString())
+ * 4. Derive payee public key using BRC-29 protocol
+ * 5. Build P2PKH locking script from derived public key
+ * 6. Create transaction via wallet with noSend: true
+ * 7. Convert transaction to base64
+ */
+export async function constructBrc121Proof(
+  challenge: Brc121Challenge,
+  wallet: Brc105Wallet,
+  origin?: string,
+): Promise<Brc121ProofResult> {
+  // Step 1: Get client's identity key
+  const { publicKey: clientIdentityKey } = await wallet.getPublicKey({ identityKey: true })
+
+  // Step 2: Generate nonce (derivation prefix) — 8 random bytes → base64
+  const nonceBytes = crypto.getRandomValues(new Uint8Array(8))
+  const nonce = btoa(String.fromCharCode(...nonceBytes))
+
+  // Step 3: Generate derivation suffix — base64 of timestamp string
+  const time = String(Date.now())
+  const timeSuffixB64 = btoa(time)
+
+  // Step 4: Derive the payee's public key via BRC-29
+  const keyID = `${nonce} ${timeSuffixB64}`
+  const { publicKey: derivedPublicKey } = await wallet.getPublicKey({
+    protocolID: [2, "3241645161d8"],
+    keyID,
+    counterparty: challenge.serverIdentityKey,
+  })
+
+  // Step 5: Build P2PKH locking script
+  const lockingScript = await pubkeyToP2PKHLockingScript(derivedPublicKey)
+
+  // Step 6: Create the payment transaction
+  const description = origin
+    ? `Payment for request to ${origin}`
+    : "BRC-121 payment"
+  const result = await wallet.createAction({
+    description,
+    outputs: [{
+      satoshis: challenge.satoshis,
+      lockingScript,
+      outputDescription: "BRC-121 payment",
+    }],
+    options: {
+      randomizeOutputs: false,
+      noSend: true,
+      returnTXIDOnly: false,
+    },
+  })
+
+  // Step 7: Convert transaction to base64
+  // SDK wallets return `tx: number[]`; CWI wallets return `rawTx: string` (hex)
+  let transactionBase64: string
+  if (result.tx && Array.isArray(result.tx) && result.tx.length > 0) {
+    transactionBase64 = numberArrayToBase64(result.tx)
+  } else if (result.rawTx && typeof result.rawTx === "string" && result.rawTx.length > 0) {
+    transactionBase64 = bytesToBase64(hexToBytes(result.rawTx))
+  } else {
+    throw new Error("Wallet returned no transaction data (neither tx nor rawTx)")
+  }
+
+  const proof = {
+    beef: transactionBase64,
+    senderIdentityKey: clientIdentityKey,
+    nonce,
+    time,
+    vout: "0",
+    txid: result.txid,
+  }
+
+  const abort = wallet.abortAction
+    ? async () => {
+        try {
+          await wallet.abortAction!({ reference: result.txid })
+        } catch (err) {
+          console.warn('[x402] abortAction failed:', err)
+        }
+      }
+    : undefined
+
+  return { proof, abort }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type { X402FetchFn } from "./x402-fetch"
 export { parseChallenge } from "./challenge"
 export { parseBrc105Challenge } from "./brc105-challenge"
 export { constructBrc105Proof } from "./brc105-proof"
+export { parseBrc121Challenge } from "./brc121-challenge"
 
 // Autospend (tier + weapon + health bar)
 export {
@@ -29,6 +30,10 @@ export type {
   Brc105Proof,
   Brc105ProofConstructor,
   Brc105Wallet,
+  Brc121Challenge,
+  Brc121Proof,
+  Brc121ProofConstructor,
+  Brc121ProofResult,
   Challenge,
   CWICreateActionOutput,
   CWICreateActionParams,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { parseChallenge } from "./challenge"
 export { parseBrc105Challenge } from "./brc105-challenge"
 export { constructBrc105Proof } from "./brc105-proof"
 export { parseBrc121Challenge } from "./brc121-challenge"
+export { constructBrc121Proof } from "./brc121-proof"
 
 // Autospend (tier + weapon + health bar)
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,9 +50,36 @@ export interface Brc105ProofResult {
 
 export type Brc105ProofConstructor = (challenge: Brc105Challenge) => Promise<Brc105ProofResult>
 
+// === BRC-121 Simple 402 types ===
+
+/** BRC-121 challenge parsed from 402 response headers. */
+export interface Brc121Challenge {
+  satoshis: number
+  serverIdentityKey: string
+}
+
+/** BRC-121 proof — maps to 5 individual HTTP headers. */
+export interface Brc121Proof {
+  beef: string               // base64-encoded BEEF (x-bsv-beef)
+  senderIdentityKey: string  // client identity key hex (x-bsv-sender)
+  nonce: string              // base64-encoded derivation prefix (x-bsv-nonce)
+  time: string               // Unix ms timestamp decimal string (x-bsv-time)
+  vout: string               // output index decimal string (x-bsv-vout)
+  txid: string               // for abort tracking (not sent as header)
+}
+
+/** Result from BRC-121 proof construction, with optional abort. */
+export interface Brc121ProofResult {
+  proof: Brc121Proof
+  abort?: () => Promise<void>
+}
+
+/** Custom BRC-121 proof constructor. */
+export type Brc121ProofConstructor = (challenge: Brc121Challenge) => Promise<Brc121ProofResult>
+
 // === Protocol-agnostic payment request ===
 
-export type PaymentProtocol = 'x402' | 'brc105'
+export type PaymentProtocol = 'x402' | 'brc105' | 'brc121'
 
 export interface PaymentRequest {
   amount: number
@@ -127,6 +154,10 @@ export interface X402Config {
   proofConstructor?: (challenge: Challenge) => Promise<Proof>
   brc105ProofConstructor?: Brc105ProofConstructor
   brc105Wallet?: Brc105Wallet
+  /** Custom BRC-121 proof constructor. */
+  brc121ProofConstructor?: Brc121ProofConstructor
+  /** Wallet for BRC-121 payments (reuses Brc105Wallet interface). */
+  brc121Wallet?: Brc105Wallet
   onProofError?: (error: unknown, protocol: PaymentProtocol) => void
   /** Maximum number of retries for network errors during BRC-105 payment (default: 2). */
   maxRetries?: number

--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { createX402Fetch, payeeAddressToLockingScript, verifyBase58Checksum } from "./x402-fetch"
-import type { Brc105Challenge, Brc105ProofResult } from "./types"
+import type { Brc105Challenge, Brc105ProofResult, Brc121Challenge, Brc121ProofResult } from "./types"
 
 function make402Response(amount: number = 1000) {
   return new Response("Payment Required", {
@@ -1266,5 +1266,352 @@ describe("createX402Fetch — BEEF acknowledgement", () => {
 
     const params = ackWallet.internalizeAction.mock.calls[0][0]
     expect(params.outputs[0].outputIndex).toBe(3)
+  })
+})
+
+// === BRC-121 tests ===
+
+function makeBrc121Response(satoshis: number = 1000, overrides: Record<string, string> = {}) {
+  return new Response("Payment Required", {
+    status: 402,
+    headers: {
+      "x-bsv-sats": String(satoshis),
+      "x-bsv-server": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      ...overrides,
+    },
+  })
+}
+
+function mockBrc121ProofConstructor(): (challenge: Brc121Challenge) => Promise<Brc121ProofResult> {
+  return vi.fn(async () => ({
+    proof: {
+      beef: btoa("test-beef"),
+      senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      nonce: btoa("12345678"),
+      time: "1719500000000",
+      vout: "0",
+      txid: "brc121-test-txid",
+    },
+    abort: vi.fn(),
+  }))
+}
+
+describe("createX402Fetch — BRC-121", () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it("detects BRC-121 402 and retries with 5 proof headers", async () => {
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const proofConstructor = mockBrc121ProofConstructor()
+    const f = createX402Fetch({ brc121ProofConstructor: proofConstructor })
+
+    const res = await f("https://api.example.com/data")
+    expect(res.status).toBe(200)
+    expect(proofConstructor).toHaveBeenCalledOnce()
+
+    const retryCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    const retryHeaders = retryCall[1]?.headers as Headers
+    expect(retryHeaders.get("x-bsv-beef")).toBe(btoa("test-beef"))
+    expect(retryHeaders.get("x-bsv-sender")).toBe("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+    expect(retryHeaders.get("x-bsv-nonce")).toBe(btoa("12345678"))
+    expect(retryHeaders.get("x-bsv-time")).toBe("1719500000000")
+    expect(retryHeaders.get("x-bsv-vout")).toBe("0")
+  })
+
+  it("passes through BRC-121 402 when no wallet or proof constructor configured", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeBrc121Response(1000))
+    const f = createX402Fetch()
+
+    const res = await f("https://api.example.com/data")
+    expect(res.status).toBe(402)
+  })
+
+  it("returns original 402 when proof construction fails", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeBrc121Response(1000))
+
+    const onProofError = vi.fn()
+    const f = createX402Fetch({
+      brc121ProofConstructor: vi.fn().mockRejectedValue(new Error("Wallet declined")),
+      onProofError,
+    })
+
+    const res = await f("https://api.example.com/data")
+    expect(res.status).toBe(402)
+    expect(onProofError).toHaveBeenCalledOnce()
+    expect(onProofError).toHaveBeenCalledWith(expect.any(Error), "brc121")
+  })
+
+  it("BRC-105 takes priority over BRC-121 when both headers present", async () => {
+    const bothHeaders = new Response("Payment Required", {
+      status: 402,
+      headers: {
+        "x-bsv-payment-version": "1.0",
+        "x-bsv-payment-satoshis-required": "1000",
+        "x-bsv-auth-identity-key": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "x-bsv-payment-derivation-prefix": "prefix",
+        "x-bsv-sats": "1000",
+        "x-bsv-server": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      },
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(bothHeaders)
+      .mockResolvedValueOnce(make200Response())
+
+    const brc105Proof = mockBrc105ProofConstructor()
+    const brc121Proof = mockBrc121ProofConstructor()
+
+    const f = createX402Fetch({
+      brc105ProofConstructor: brc105Proof,
+      brc121ProofConstructor: brc121Proof,
+    })
+
+    await f("https://api.example.com/data")
+
+    expect(brc105Proof).toHaveBeenCalledOnce()
+    expect(brc121Proof).not.toHaveBeenCalled()
+
+    const retryCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    const retryHeaders = retryCall[1]?.headers as Headers
+    expect(retryHeaders.get("x-bsv-payment")).toBeTruthy()
+    expect(retryHeaders.get("x-bsv-beef")).toBeNull()
+  })
+
+  it("X402 takes priority over BRC-121 when both headers present", async () => {
+    const bothHeaders = new Response("Payment Required", {
+      status: 402,
+      headers: {
+        "X402-Challenge": JSON.stringify({
+          nonce: "test-nonce",
+          payee: "1TestAddr",
+          amount: 1000,
+          network: "mainnet",
+        }),
+        "x-bsv-sats": "1000",
+        "x-bsv-server": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      },
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(bothHeaders)
+      .mockResolvedValueOnce(make200Response())
+
+    const customProof = vi.fn().mockResolvedValue({ txid: "custom-txid", beef: btoa("mock-tx") })
+    const brc121Proof = mockBrc121ProofConstructor()
+
+    const f = createX402Fetch({
+      proofConstructor: customProof,
+      brc121ProofConstructor: brc121Proof,
+    })
+
+    await f("https://api.example.com/data")
+
+    expect(customProof).toHaveBeenCalledOnce()
+    expect(brc121Proof).not.toHaveBeenCalled()
+
+    const retryCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    const retryHeaders = retryCall[1]?.headers as Headers
+    expect(retryHeaders.get("X402-Proof")).toBeTruthy()
+    expect(retryHeaders.get("x-bsv-beef")).toBeNull()
+  })
+
+  it("does not call abort when server returns 200", async () => {
+    const abort = vi.fn()
+    const brc121Proof = vi.fn().mockResolvedValue({
+      proof: {
+        beef: btoa("test-beef"),
+        senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        nonce: btoa("12345678"),
+        time: "1719500000000",
+        vout: "0",
+        txid: "brc121-ok-txid",
+      },
+      abort,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(abort).not.toHaveBeenCalled()
+  })
+
+  it("calls abort and retries with fresh proof when server returns 500", async () => {
+    const abort = vi.fn()
+    const freshAbort = vi.fn()
+    let callCount = 0
+    const brc121Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          beef: callCount === 1 ? btoa("original-beef") : btoa("fresh-beef"),
+          senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          nonce: btoa("12345678"),
+          time: "1719500000000",
+          vout: "0",
+          txid: callCount === 1 ? "original-txid" : "fresh-txid",
+        },
+        abort: callCount === 1 ? abort : freshAbort,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(abort).toHaveBeenCalledOnce()
+    expect(freshAbort).not.toHaveBeenCalled()
+    expect(brc121Proof).toHaveBeenCalledTimes(2)
+  })
+
+  it("retries same proof on network error then succeeds on 200", async () => {
+    const abort = vi.fn()
+    const brc121Proof = vi.fn().mockResolvedValue({
+      proof: {
+        beef: btoa("test-beef"),
+        senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        nonce: btoa("12345678"),
+        time: "1719500000000",
+        vout: "0",
+        txid: "brc121-retry-txid",
+      },
+      abort,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof, maxRetries: 1 })
+
+    vi.useFakeTimers()
+    const promise = f("https://api.example.com/data")
+    await vi.advanceTimersByTimeAsync(1000)
+    const res = await promise
+    vi.useRealTimers()
+
+    expect(res.status).toBe(200)
+    expect(abort).not.toHaveBeenCalled()
+    expect(brc121Proof).toHaveBeenCalledOnce()
+
+    // Same proof headers reused on both attempts
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    const firstRetryBeef = (fetchMock.mock.calls[1][1]?.headers as Headers).get("x-bsv-beef")
+    const secondRetryBeef = (fetchMock.mock.calls[2][1]?.headers as Headers).get("x-bsv-beef")
+    expect(firstRetryBeef).toBe(secondRetryBeef)
+  })
+
+  it("throws 'payment state unknown' when all network retries exhausted", async () => {
+    const abort = vi.fn()
+    const brc121Proof = vi.fn().mockResolvedValue({
+      proof: {
+        beef: btoa("test-beef"),
+        senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        nonce: btoa("12345678"),
+        time: "1719500000000",
+        vout: "0",
+        txid: "brc121-fail-txid",
+      },
+      abort,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockRejectedValue(new TypeError("Failed to fetch"))
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof, maxRetries: 0 })
+    await expect(f("https://api.example.com/data")).rejects.toThrow("Payment state unknown")
+    expect(abort).not.toHaveBeenCalled()
+  })
+
+  it("processes pendingBeefs on successful BRC-121 response", async () => {
+    const ackWallet = { internalizeAction: vi.fn().mockResolvedValue({ accepted: true }) }
+    const serverIdentityKey = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    const brc121Proof = mockBrc121ProofConstructor()
+
+    // 402 → proof → 200 with pendingBeefs
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(500))
+      .mockResolvedValueOnce(make200WithPendingBeefs([makePendingBeef({ txid: "brc121-ack" })]))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ ackWallet, serverIdentityKey, brc121ProofConstructor: brc121Proof })
+
+    const res1 = await f("https://api.example.com/paid")
+    expect(res1.status).toBe(200)
+    expect(ackWallet.internalizeAction).toHaveBeenCalledTimes(1)
+
+    // Second call: should carry x-bsv-ack
+    await f("https://api.example.com/next")
+
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    const nextHeaders = fetchMock.mock.calls[2][1]?.headers as Headers
+    expect(nextHeaders.get("x-bsv-ack")).toBe("brc121-ack")
+  })
+
+  it("injects ack headers on BRC-121 retry requests", async () => {
+    const ackWallet = { internalizeAction: vi.fn().mockResolvedValue({ accepted: true }) }
+    const serverIdentityKey = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    const brc121Proof = mockBrc121ProofConstructor()
+
+    // First call: 200 with pendingBeefs (primes the ack)
+    // Second call: 402 BRC-121 → retry should carry ack header
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(make200WithPendingBeefs([makePendingBeef({ txid: "pre-ack" })]))
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ ackWallet, serverIdentityKey, brc121ProofConstructor: brc121Proof })
+
+    await f("https://api.example.com/first")
+    await f("https://api.example.com/second")
+
+    // The second fetch (index 1) is the initial 402 — the third (index 2) is the retry
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    // The initial request of the second call should have carried the ack from first response
+    const secondInitialHeaders = fetchMock.mock.calls[1][1]?.headers as Headers
+    expect(secondInitialHeaders.get("x-bsv-ack")).toBe("pre-ack")
+  })
+
+  it("uses exact header names matching @bsv/402-pay format", async () => {
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const brc121Proof = mockBrc121ProofConstructor()
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof })
+
+    await f("https://api.example.com/data")
+
+    const retryCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    const retryHeaders = retryCall[1]?.headers as Headers
+
+    // Verify exact header names (lowercase x-bsv-* per convention)
+    const headerNames = [...(retryHeaders as any).entries()].map(([k]: [string, string]) => k)
+    expect(headerNames).toContain("x-bsv-beef")
+    expect(headerNames).toContain("x-bsv-sender")
+    expect(headerNames).toContain("x-bsv-nonce")
+    expect(headerNames).toContain("x-bsv-time")
+    expect(headerNames).toContain("x-bsv-vout")
   })
 })

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -1,8 +1,11 @@
 import { parseBrc105Challenge } from "./brc105-challenge"
 import { constructBrc105Proof } from "./brc105-proof"
+import { parseBrc121Challenge } from "./brc121-challenge"
+import { constructBrc121Proof } from "./brc121-proof"
 import { parseChallenge } from "./challenge"
 import type {
   Brc105Challenge,
+  Brc121Challenge,
   Challenge,
   Proof,
   X402Config,
@@ -174,6 +177,8 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
   const constructProof = config.proofConstructor ?? defaultConstructProof
   const brc105ProofConstructor = config.brc105ProofConstructor
   const brc105Wallet = config.brc105Wallet
+  const brc121ProofConstructor = config.brc121ProofConstructor
+  const brc121Wallet = config.brc121Wallet
   const maxRetries = config.maxRetries ?? 2
   const ackWallet = config.ackWallet
   const serverIdentityKey = config.serverIdentityKey
@@ -394,6 +399,132 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
         try {
           await freshAbort()
           console.warn('[x402] Server rejected fresh BRC-105 payment, UTXOs released via abortAction')
+        } catch (err) {
+          console.warn('[x402] freshAbort failed during double rejection:', err)
+        }
+      }
+
+      await processPendingBeefs(freshResponse)
+      return freshResponse
+    }
+
+    // BRC-121 protocol: x-bsv-sats + x-bsv-server (no x-bsv-payment-version)
+    let brc121Challenge: Brc121Challenge | null
+    try {
+      brc121Challenge = parseBrc121Challenge(response)
+    } catch {
+      // Malformed challenge — treat as non-payable
+      return response
+    }
+
+    if (brc121Challenge) {
+      // No BRC-121 wallet or proof constructor configured — pass through silently
+      if (!brc121ProofConstructor && !brc121Wallet) {
+        await processPendingBeefs(response)
+        return response
+      }
+
+      // Helper: build proof using whichever constructor is configured
+      const buildProof = async () => {
+        if (brc121ProofConstructor) {
+          return brc121ProofConstructor(brc121Challenge!)
+        }
+        return constructBrc121Proof(brc121Challenge!, brc121Wallet!, origin)
+      }
+
+      // Helper: build headers from a proof
+      const proofHeaders = (proof: import("./types").Brc121Proof) => {
+        const h = new Headers(init?.headers)
+        h.set("x-bsv-beef", proof.beef)
+        h.set("x-bsv-sender", proof.senderIdentityKey)
+        h.set("x-bsv-nonce", proof.nonce)
+        h.set("x-bsv-time", proof.time)
+        h.set("x-bsv-vout", proof.vout)
+        injectAckHeader(h)
+        return h
+      }
+
+      let proof: import("./types").Brc121Proof
+      let abort: (() => Promise<void>) | undefined
+      try {
+        const result = await buildProof()
+        proof = result.proof
+        abort = result.abort
+      } catch (err) {
+        console.error("[x402] Proof construction failed (brc121):", err)
+        config.onProofError?.(err, "brc121")
+        return response
+      }
+
+      // --- Network retry loop: resend the same signed tx ---
+      let retryResponse: Response | undefined
+      let networkError = false
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        if (attempt > 0) {
+          await delay(1000 * 2 ** (attempt - 1))
+        }
+        try {
+          retryResponse = await fetch(input, { ...init, headers: proofHeaders(proof) })
+          networkError = false
+          break
+        } catch {
+          networkError = true
+        }
+      }
+
+      // Network error: all retries exhausted — do NOT abort (tx may be on-chain)
+      if (networkError) {
+        throw new Error(
+          "[x402] Payment state unknown: network error after " +
+          `${maxRetries + 1} attempts. The transaction may have been broadcast — ` +
+          "do not retry with a new transaction without checking on-chain state.",
+        )
+      }
+
+      // Success
+      if (retryResponse!.ok) {
+        await processPendingBeefs(retryResponse!)
+        return retryResponse!
+      }
+
+      // --- Server rejection: abort, then single fresh retry ---
+      if (abort) {
+        try {
+          await abort()
+          console.warn('[x402] Server rejected BRC-121 payment, UTXOs released via abortAction')
+        } catch (err) {
+          console.warn('[x402] abortAction failed during server rejection:', err)
+        }
+      }
+
+      let freshProof: import("./types").Brc121Proof
+      let freshAbort: (() => Promise<void>) | undefined
+      try {
+        const result = await buildProof()
+        freshProof = result.proof
+        freshAbort = result.abort
+      } catch (err) {
+        console.error("[x402] Fresh proof construction failed (brc121):", err)
+        config.onProofError?.(err, "brc121")
+        return retryResponse!
+      }
+
+      let freshResponse: Response
+      try {
+        freshResponse = await fetch(input, { ...init, headers: proofHeaders(freshProof) })
+      } catch {
+        // Network error on fresh attempt — do NOT abort (tx may be on-chain)
+        throw new Error(
+          "[x402] Payment state unknown: network error on fresh retry. " +
+          "The transaction may have been broadcast — " +
+          "do not retry with a new transaction without checking on-chain state.",
+        )
+      }
+
+      if (!freshResponse.ok && freshAbort) {
+        try {
+          await freshAbort()
+          console.warn('[x402] Server rejected fresh BRC-121 payment, UTXOs released via abortAction')
         } catch (err) {
           console.warn('[x402] freshAbort failed during double rejection:', err)
         }


### PR DESCRIPTION
## Summary
- Added BRC-121 as third protocol in the multi-protocol detection chain (X402 > BRC-105 > BRC-121)
- Challenge parsing: `x-bsv-sats` + `x-bsv-server` headers, with BRC-105 discrimination (returns null when `x-bsv-payment-version` present)
- Proof construction: BRC-29 key derivation with client-generated timestamp suffix, 8-byte random nonce, `noSend: true`, `randomizeOutputs: false`
- Proof sent as 5 individual headers (`x-bsv-beef`, `x-bsv-sender`, `x-bsv-nonce`, `x-bsv-time`, `x-bsv-vout`) matching `@bsv/402-pay` reference format
- Three-state retry: network error (retry same proof), server rejection (abort + fresh retry), success (return)
- Pending BEEF processing and ack headers work on BRC-121 responses
- `brc121ProofConstructor` and `brc121Wallet` config options for extension/override
- 41 new tests: challenge parsing (11), proof construction (18), fetch integration (12)
- Zero behavioural change to existing X402 and BRC-105 flows

## Test plan
- [x] All 272 tests pass
- [x] Build clean (ESM + CJS + DTS)
- [x] Typecheck clean
- [x] Acceptance criteria for #139, #140, and #141 verified

Closes #138

Generated with [Claude Code](https://claude.com/claude-code)
