### PR TITLE
feat: broadcast nosend transactions on server 200 acceptance

### DIFF
--- a/src/brc105-proof.test.ts
+++ b/src/brc105-proof.test.ts
@@ -352,4 +352,31 @@ describe("constructBrc105Proof", () => {
       "HMAC generation failed",
     )
   })
+
+  it("returns broadcast callback that calls wallet.createAction with sendWith", async () => {
+    const wallet = mockWallet()
+    const { proof, broadcast } = await constructBrc105Proof(CHALLENGE, wallet)
+
+    expect(broadcast).toBeDefined()
+    await broadcast!()
+    // createAction is called once for the payment, once for broadcast
+    const calls = (wallet.createAction as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls).toHaveLength(2)
+    expect(calls[1][0]).toEqual({
+      description: 'Broadcast x402 payment',
+      outputs: [],
+      options: { sendWith: [proof.txid] },
+    })
+  })
+
+  it("broadcast callback swallows errors from wallet.createAction", async () => {
+    const createAction = vi.fn()
+      .mockResolvedValueOnce({ txid: "aabbccdd", rawTx: "0100000001000000000000000000" })
+      .mockRejectedValueOnce(new Error("broadcast failed"))
+    const wallet = mockWallet({ createAction })
+    const { broadcast } = await constructBrc105Proof(CHALLENGE, wallet)
+
+    expect(broadcast).toBeDefined()
+    await expect(broadcast!()).resolves.toBeUndefined()
+  })
 })

--- a/src/brc105-proof.ts
+++ b/src/brc105-proof.ts
@@ -282,7 +282,21 @@ export async function constructBrc105Proof(
       }
     : undefined
 
-  return { proof, abort }
+  const broadcast = wallet.createAction
+    ? async () => {
+        try {
+          await wallet.createAction({
+            description: 'Broadcast x402 payment',
+            outputs: [],
+            options: { sendWith: [result.txid] },
+          })
+        } catch (err) {
+          console.warn('[x402] broadcast failed:', err)
+        }
+      }
+    : undefined
+
+  return { proof, abort, broadcast }
 }
 
 // Exported for testing

--- a/src/brc121-proof.test.ts
+++ b/src/brc121-proof.test.ts
@@ -215,4 +215,31 @@ describe("constructBrc121Proof", () => {
     const params = (wallet.createAction as ReturnType<typeof vi.fn>).mock.calls[0][0]
     expect(params.description).toBe("BRC-121 payment")
   })
+
+  it("returns broadcast callback that calls wallet.createAction with sendWith", async () => {
+    const wallet = mockWallet()
+    const { proof, broadcast } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(broadcast).toBeDefined()
+    await broadcast!()
+    // createAction is called once for the payment, once for broadcast
+    const calls = (wallet.createAction as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls).toHaveLength(2)
+    expect(calls[1][0]).toEqual({
+      description: 'Broadcast x402 payment',
+      outputs: [],
+      options: { sendWith: [proof.txid] },
+    })
+  })
+
+  it("broadcast callback swallows errors from wallet.createAction", async () => {
+    const createAction = vi.fn()
+      .mockResolvedValueOnce({ txid: "abc123def456", tx: Array.from({ length: 20 }, (_, i) => i) })
+      .mockRejectedValueOnce(new Error("broadcast failed"))
+    const wallet = mockWallet({ createAction })
+    const { broadcast } = await constructBrc121Proof(CHALLENGE, wallet)
+
+    expect(broadcast).toBeDefined()
+    await expect(broadcast!()).resolves.toBeUndefined()
+  })
 })

--- a/src/brc121-proof.ts
+++ b/src/brc121-proof.ts
@@ -111,5 +111,19 @@ export async function constructBrc121Proof(
       }
     : undefined
 
-  return { proof, abort }
+  const broadcast = wallet.createAction
+    ? async () => {
+        try {
+          await wallet.createAction({
+            description: 'Broadcast x402 payment',
+            outputs: [],
+            options: { sendWith: [result.txid] },
+          })
+        } catch (err) {
+          console.warn('[x402] broadcast failed:', err)
+        }
+      }
+    : undefined
+
+  return { proof, abort, broadcast }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,7 @@ export interface CWICreateActionParams {
     returnTXIDOnly?: boolean
     noSend?: boolean
     randomizeOutputs?: boolean
+    sendWith?: string[]
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export interface Brc105Proof {
 export interface Brc105ProofResult {
   proof: Brc105Proof
   abort?: () => Promise<void>
+  broadcast?: () => Promise<void>
 }
 
 export type Brc105ProofConstructor = (challenge: Brc105Challenge) => Promise<Brc105ProofResult>
@@ -72,6 +73,7 @@ export interface Brc121Proof {
 export interface Brc121ProofResult {
   proof: Brc121Proof
   abort?: () => Promise<void>
+  broadcast?: () => Promise<void>
 }
 
 /** Custom BRC-121 proof constructor. */

--- a/src/x402-fetch.test.ts
+++ b/src/x402-fetch.test.ts
@@ -810,6 +810,143 @@ describe("createX402Fetch — BRC-105", () => {
     expect(abort).toHaveBeenCalledOnce()
     expect(brc105Proof).toHaveBeenCalledTimes(2)
   })
+
+  it("calls broadcast on server 200 acceptance", async () => {
+    const broadcast = vi.fn().mockResolvedValue(undefined)
+    const brc105Proof = vi.fn().mockResolvedValue({
+      proof: {
+        derivationPrefix: "prefix",
+        derivationSuffix: "suffix",
+        transaction: "dHg=",
+        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        txid: "abc123",
+      },
+      abort: vi.fn(),
+      broadcast,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(broadcast).toHaveBeenCalledOnce()
+  })
+
+  it("does not call broadcast on server 4xx rejection", async () => {
+    const broadcast = vi.fn()
+    const abort = vi.fn()
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: "suffix-" + callCount,
+          transaction: "dHg=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: "txid-" + callCount,
+        },
+        abort,
+        broadcast,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Bad Request", { status: 400 }))
+      .mockResolvedValueOnce(new Response("Bad Request Again", { status: 400 }))
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(400)
+    expect(broadcast).not.toHaveBeenCalled()
+    expect(abort).toHaveBeenCalled()
+  })
+
+  it("returns response even when broadcast throws", async () => {
+    const broadcast = vi.fn().mockRejectedValue(new Error("ARC unavailable"))
+    const brc105Proof = vi.fn().mockResolvedValue({
+      proof: {
+        derivationPrefix: "prefix",
+        derivationSuffix: "suffix",
+        transaction: "dHg=",
+        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        txid: "abc123",
+      },
+      broadcast,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(broadcast).toHaveBeenCalledOnce()
+  })
+
+  it("handles undefined broadcast gracefully (custom constructor)", async () => {
+    const brc105Proof = vi.fn().mockResolvedValue({
+      proof: {
+        derivationPrefix: "prefix",
+        derivationSuffix: "suffix",
+        transaction: "dHg=",
+        clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        txid: "abc123",
+      },
+      // no broadcast
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+  })
+
+  it("calls fresh broadcast on server rejection then fresh retry success", async () => {
+    const broadcast = vi.fn().mockResolvedValue(undefined)
+    const freshBroadcast = vi.fn().mockResolvedValue(undefined)
+    let callCount = 0
+    const brc105Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          derivationPrefix: "prefix",
+          derivationSuffix: "suffix-" + callCount,
+          transaction: callCount === 1 ? "b3JpZw==" : "ZnJlc2g=",
+          clientIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          txid: "txid-" + callCount,
+        },
+        abort: vi.fn(),
+        broadcast: callCount === 1 ? broadcast : freshBroadcast,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc105Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc105ProofConstructor: brc105Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    // Original broadcast NOT called (server rejected original proof)
+    expect(broadcast).not.toHaveBeenCalled()
+    // Fresh broadcast called on success
+    expect(freshBroadcast).toHaveBeenCalledOnce()
+  })
 })
 
 // === BEEF acknowledgement tests ===
@@ -1613,5 +1750,147 @@ describe("createX402Fetch — BRC-121", () => {
     expect(headerNames).toContain("x-bsv-nonce")
     expect(headerNames).toContain("x-bsv-time")
     expect(headerNames).toContain("x-bsv-vout")
+  })
+
+  it("calls broadcast on server 200 acceptance", async () => {
+    const broadcast = vi.fn().mockResolvedValue(undefined)
+    const brc121Proof = vi.fn().mockResolvedValue({
+      proof: {
+        beef: btoa("test-beef"),
+        senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        nonce: btoa("12345678"),
+        time: "1719500000000",
+        vout: "0",
+        txid: "brc121-broadcast-txid",
+      },
+      abort: vi.fn(),
+      broadcast,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(broadcast).toHaveBeenCalledOnce()
+  })
+
+  it("does not call broadcast on server 4xx rejection", async () => {
+    const broadcast = vi.fn()
+    const abort = vi.fn()
+    let callCount = 0
+    const brc121Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          beef: btoa("test-beef"),
+          senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          nonce: btoa("12345678"),
+          time: "1719500000000",
+          vout: "0",
+          txid: "txid-" + callCount,
+        },
+        abort,
+        broadcast,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(new Response("Bad Request", { status: 400 }))
+      .mockResolvedValueOnce(new Response("Bad Request Again", { status: 400 }))
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(400)
+    expect(broadcast).not.toHaveBeenCalled()
+    expect(abort).toHaveBeenCalled()
+  })
+
+  it("returns response even when broadcast throws", async () => {
+    const broadcast = vi.fn().mockRejectedValue(new Error("ARC unavailable"))
+    const brc121Proof = vi.fn().mockResolvedValue({
+      proof: {
+        beef: btoa("test-beef"),
+        senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        nonce: btoa("12345678"),
+        time: "1719500000000",
+        vout: "0",
+        txid: "brc121-err-txid",
+      },
+      broadcast,
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    expect(broadcast).toHaveBeenCalledOnce()
+  })
+
+  it("handles undefined broadcast gracefully (custom constructor)", async () => {
+    const brc121Proof = vi.fn().mockResolvedValue({
+      proof: {
+        beef: btoa("test-beef"),
+        senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        nonce: btoa("12345678"),
+        time: "1719500000000",
+        vout: "0",
+        txid: "brc121-nobc-txid",
+      },
+      // no broadcast
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+  })
+
+  it("calls fresh broadcast on server rejection then fresh retry success", async () => {
+    const broadcast = vi.fn().mockResolvedValue(undefined)
+    const freshBroadcast = vi.fn().mockResolvedValue(undefined)
+    let callCount = 0
+    const brc121Proof = vi.fn().mockImplementation(async () => {
+      callCount++
+      return {
+        proof: {
+          beef: callCount === 1 ? btoa("original-beef") : btoa("fresh-beef"),
+          senderIdentityKey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          nonce: btoa("12345678"),
+          time: "1719500000000",
+          vout: "0",
+          txid: callCount === 1 ? "original-txid" : "fresh-txid",
+        },
+        abort: vi.fn(),
+        broadcast: callCount === 1 ? broadcast : freshBroadcast,
+      }
+    })
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(makeBrc121Response(1000))
+      .mockResolvedValueOnce(new Response("Server Error", { status: 500 }))
+      .mockResolvedValueOnce(make200Response())
+
+    const f = createX402Fetch({ brc121ProofConstructor: brc121Proof })
+    const res = await f("https://api.example.com/data")
+
+    expect(res.status).toBe(200)
+    // Original broadcast NOT called (server rejected original proof)
+    expect(broadcast).not.toHaveBeenCalled()
+    // Fresh broadcast called on success
+    expect(freshBroadcast).toHaveBeenCalledOnce()
   })
 })

--- a/src/x402-fetch.ts
+++ b/src/x402-fetch.ts
@@ -320,10 +320,12 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
 
       let proof: import("./types").Brc105Proof
       let abort: (() => Promise<void>) | undefined
+      let broadcast: (() => Promise<void>) | undefined
       try {
         const result = await buildProof()
         proof = result.proof
         abort = result.abort
+        broadcast = result.broadcast
       } catch (err) {
         console.error("[x402] Proof construction failed (brc105):", err)
         config.onProofError?.(err, "brc105")
@@ -357,6 +359,9 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
 
       // Success
       if (retryResponse!.ok) {
+        if (broadcast) {
+          broadcast().catch(err => console.warn('[x402] broadcast failed:', err))
+        }
         await processPendingBeefs(retryResponse!)
         return retryResponse!
       }
@@ -373,10 +378,12 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
 
       let freshProof: import("./types").Brc105Proof
       let freshAbort: (() => Promise<void>) | undefined
+      let freshBroadcast: (() => Promise<void>) | undefined
       try {
         const result = await buildProof()
         freshProof = result.proof
         freshAbort = result.abort
+        freshBroadcast = result.broadcast
       } catch (err) {
         console.error("[x402] Fresh proof construction failed (brc105):", err)
         config.onProofError?.(err, "brc105")
@@ -395,7 +402,11 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
         )
       }
 
-      if (!freshResponse.ok && freshAbort) {
+      if (freshResponse.ok) {
+        if (freshBroadcast) {
+          freshBroadcast().catch(err => console.warn('[x402] broadcast failed:', err))
+        }
+      } else if (freshAbort) {
         try {
           await freshAbort()
           console.warn('[x402] Server rejected fresh BRC-105 payment, UTXOs released via abortAction')
@@ -446,10 +457,12 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
 
       let proof: import("./types").Brc121Proof
       let abort: (() => Promise<void>) | undefined
+      let broadcast: (() => Promise<void>) | undefined
       try {
         const result = await buildProof()
         proof = result.proof
         abort = result.abort
+        broadcast = result.broadcast
       } catch (err) {
         console.error("[x402] Proof construction failed (brc121):", err)
         config.onProofError?.(err, "brc121")
@@ -483,6 +496,9 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
 
       // Success
       if (retryResponse!.ok) {
+        if (broadcast) {
+          broadcast().catch(err => console.warn('[x402] broadcast failed:', err))
+        }
         await processPendingBeefs(retryResponse!)
         return retryResponse!
       }
@@ -499,10 +515,12 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
 
       let freshProof: import("./types").Brc121Proof
       let freshAbort: (() => Promise<void>) | undefined
+      let freshBroadcast: (() => Promise<void>) | undefined
       try {
         const result = await buildProof()
         freshProof = result.proof
         freshAbort = result.abort
+        freshBroadcast = result.broadcast
       } catch (err) {
         console.error("[x402] Fresh proof construction failed (brc121):", err)
         config.onProofError?.(err, "brc121")
@@ -521,7 +539,11 @@ export function createX402Fetch(config: X402Config = {}): X402FetchFn {
         )
       }
 
-      if (!freshResponse.ok && freshAbort) {
+      if (freshResponse.ok) {
+        if (freshBroadcast) {
+          freshBroadcast().catch(err => console.warn('[x402] broadcast failed:', err))
+        }
+      } else if (freshAbort) {
         try {
           await freshAbort()
           console.warn('[x402] Server rejected fresh BRC-121 payment, UTXOs released via abortAction')


### PR DESCRIPTION
## Summary
- Add `sendWith` option to `CWICreateActionParams` for triggering broadcast of nosend transactions
- Add `broadcast` callback to BRC-105 and BRC-121 proof results (symmetric with existing `abort`)
- Call `broadcast()` on server 200 in x402-fetch for both BRC-105 and BRC-121 flows
- Fire-and-forget broadcast — failures logged but never block the response

## Test plan
- [x] All tests pass (286 total, 16 new)
- [x] Typecheck clean
- [x] Acceptance criteria verified against HLR #151

Closes #151
