### PR TITLE
fix: CWI proxy allows sendWith broadcast calls

### DIFF
--- a/plugins/shared/cwi-conformance.test.ts
+++ b/plugins/shared/cwi-conformance.test.ts
@@ -481,6 +481,72 @@ describe('CWI conformance: spending limits', () => {
 })
 
 // ---------------------------------------------------------------------------
+// 4b. sendWith broadcast bypass — broadcast-only createAction calls
+//
+// When createAction is called with empty outputs and a non-empty sendWith,
+// it broadcasts a previously-created nosend transaction. Spending was
+// already recorded when the nosend tx was created — no validation needed.
+// ---------------------------------------------------------------------------
+
+describe('CWI conformance: sendWith broadcast bypass', () => {
+  it('allows createAction with empty outputs when sendWith is set', async () => {
+    const msg = makeMessage('createAction', {
+      description: 'Broadcast x402 payment',
+      outputs: [],
+      options: { sendWith: ['abc123'] },
+    })
+    const response = await handleCWIRequest(msg, backend)
+
+    expect(response.status).toBe('ok')
+    // Backend reached
+    expect(backend.calls).toHaveLength(1)
+    expect(backend.calls[0].method).toBe('createAction')
+    // No spend check, no payment recorded — already done at nosend creation
+    expect(mockCheckSpendLimits).not.toHaveBeenCalled()
+    expect(mockRecordPayment).not.toHaveBeenCalled()
+  })
+
+  it('still rejects empty outputs without sendWith', async () => {
+    const msg = makeMessage('createAction', {
+      description: 'test',
+      outputs: [],
+    })
+    const response = await handleCWIRequest(msg, backend)
+
+    expect(response.status).toBe('error')
+    expect(response.error).toContain('Missing or empty outputs')
+    expect(backend.calls).toHaveLength(0)
+  })
+
+  it('still rejects empty outputs with empty sendWith array', async () => {
+    const msg = makeMessage('createAction', {
+      description: 'test',
+      outputs: [],
+      options: { sendWith: [] },
+    })
+    const response = await handleCWIRequest(msg, backend)
+
+    expect(response.status).toBe('error')
+    expect(response.error).toContain('Missing or empty outputs')
+    expect(backend.calls).toHaveLength(0)
+  })
+
+  it('runs full validation when both outputs and sendWith are present', async () => {
+    const msg = makeMessage('createAction', {
+      description: 'test',
+      outputs: [{ satoshis: 200, lockingScript: '00', outputDescription: 'a' }],
+      options: { sendWith: ['abc123'] },
+    })
+    await handleCWIRequest(msg, backend)
+
+    // outputs is non-empty → broadcast bypass does NOT apply, validation runs
+    expect(mockCheckSpendLimits).toHaveBeenCalledTimes(1)
+    expect(mockCheckSpendLimits.mock.calls[0][0].amount).toBe(200)
+    expect(mockRecordPayment).toHaveBeenCalledWith(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // 5. BRC-105 proof construction flow
 //
 // Verifies that the three-step BRC-105 sequence (createHmac → getPublicKey →

--- a/plugins/shared/cwi-proxy.ts
+++ b/plugins/shared/cwi-proxy.ts
@@ -25,43 +25,56 @@ export async function handleCWIRequest(
     // Spending check — only on createAction (the method that commits satoshis)
     let validatedSatoshis: number | undefined
     if (request.method === 'createAction') {
-      const params = request.params as { outputs?: Array<{ satoshis: unknown }> } | undefined
+      const params = request.params as {
+        outputs?: Array<{ satoshis: unknown }>
+        options?: { sendWith?: unknown }
+      } | undefined
       const outputs = params?.outputs
+      const sendWith = params?.options?.sendWith
+      const isBroadcastOnly = Array.isArray(sendWith) && sendWith.length > 0
+        && (!Array.isArray(outputs) || outputs.length === 0)
 
-      if (!Array.isArray(outputs) || outputs.length === 0) {
-        return { id: request.id, status: 'error', error: 'Missing or empty outputs for createAction' }
-      }
-
-      // Validate each output's satoshis — must be a positive safe integer, total must stay safe
-      let total = 0
-      for (const o of outputs) {
-        if (typeof o.satoshis !== 'number' || !Number.isSafeInteger(o.satoshis) || o.satoshis <= 0) {
-          return { id: request.id, status: 'error', error: 'Invalid satoshis value in outputs' }
+      if (isBroadcastOnly) {
+        // sendWith-only call broadcasts existing nosend transactions — no new
+        // spend to validate, no autospend check (already recorded when nosend
+        // was created). Skip straight to backend delegation.
+        console.debug('[x402] CWI proxy: sendWith broadcast for', sendWith)
+      } else {
+        if (!Array.isArray(outputs) || outputs.length === 0) {
+          return { id: request.id, status: 'error', error: 'Missing or empty outputs for createAction' }
         }
-        total += o.satoshis
-        if (!Number.isSafeInteger(total)) {
-          return { id: request.id, status: 'error', error: 'Total satoshis exceeds safe integer range' }
-        }
-      }
-      validatedSatoshis = total
 
-      const paymentRequest: PaymentRequest = {
-        amount: validatedSatoshis,
-        origin,
-        protocol: 'x402',
-      }
-
-      const check = checkSpendLimits(paymentRequest)
-      if (!check.allowed) {
-        if (check.requiresConfirmation) {
-          // Payment exceeds autospend — prompt the user
-          const approved = await requestApproval({ amount: validatedSatoshis, origin })
-          if (!approved) {
-            return { id: request.id, status: 'error', error: 'Payment denied by user' }
+        // Validate each output's satoshis — must be a positive safe integer, total must stay safe
+        let total = 0
+        for (const o of outputs) {
+          if (typeof o.satoshis !== 'number' || !Number.isSafeInteger(o.satoshis) || o.satoshis <= 0) {
+            return { id: request.id, status: 'error', error: 'Invalid satoshis value in outputs' }
           }
-          // User approved — proceed
-        } else {
-          return { id: request.id, status: 'error', error: check.reason ?? 'Payment blocked' }
+          total += o.satoshis
+          if (!Number.isSafeInteger(total)) {
+            return { id: request.id, status: 'error', error: 'Total satoshis exceeds safe integer range' }
+          }
+        }
+        validatedSatoshis = total
+
+        const paymentRequest: PaymentRequest = {
+          amount: validatedSatoshis,
+          origin,
+          protocol: 'x402',
+        }
+
+        const check = checkSpendLimits(paymentRequest)
+        if (!check.allowed) {
+          if (check.requiresConfirmation) {
+            // Payment exceeds autospend — prompt the user
+            const approved = await requestApproval({ amount: validatedSatoshis, origin })
+            if (!approved) {
+              return { id: request.id, status: 'error', error: 'Payment denied by user' }
+            }
+            // User approved — proceed
+          } else {
+            return { id: request.id, status: 'error', error: check.reason ?? 'Payment blocked' }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- CWI proxy now allows `createAction({ outputs: [], options: { sendWith: [...] } })` — the broadcast-on-200 path that v0.9.0 was supposed to enable
- Skips autospend check for sendWith-only calls (no new spend; already recorded at nosend creation)
- Combined `outputs + sendWith` calls still go through full validation
- 4 new tests in cwi-conformance.test.ts
- Debug log on bypass path for future diagnostics

## Test plan

- [x] All 311 tests pass (4 new)
- [x] Typecheck clean
- [x] Manual verification needed: BRC-105/BRC-121 e2e payment → nosend tx broadcast on 200

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)