### PR TITLE
feat: popup UI/UX overhaul — multi-page navigation (#160)

### DIFF
--- a/.claude/plans/20260419-ui-ux-overhaul.md
+++ b/.claude/plans/20260419-ui-ux-overhaul.md
@@ -1,0 +1,216 @@
+# Plan: Popup UI/UX Overhaul
+
+## Context
+
+The current popup is a single 454-line `popup.ts` with inline DOM manipulation, no routing, and a flash-of-locked-state bug. The user wants multi-page navigation (Home, Payments, Transactions, Settings), a transaction list with paging, QR receive codes, and wallet recovery (SQLite export/import). Requirements in `/opt/js/bsv-x402/tmp/ui-ux.md`.
+
+The model layer (service worker) and controller (message protocol) don't change. This is purely a view restructure.
+
+## Architecture
+
+```
+plugins/shared/ui/
+  popup.html          → shell: header tabs + container div (minimal HTML)
+  popup.css           → all styles (rewritten for new layout)
+  popup.ts            → init, router, state fetcher (tiny ~60 lines)
+  state.ts            → PopupState type, sendMessage helper, state polling
+  router.ts           → hash-based page switching, renders active page into container
+  pages/
+    home.ts           → balance, autospend health bar, pickups
+    payments.ts       → send/receive toggle, send form, QR code, identity/address
+    transactions.ts   → tx list with pager, tx rows linking to WoC
+    settings.ts       → tier, weapon, tools (verify/admin), recovery (export/import)
+  components/
+    header.ts         → tab navigation (Home | Payments | Transactions | Settings)
+    tx-row.ts         → single transaction row (amount, status badge, description, txid link)
+    health-bar.ts     → autospend health bar (reused from current code)
+    qr.ts             → QR code rendering (lightweight library or canvas-based)
+```
+
+### Page rendering pattern
+
+Each page exports a `render(container, state)` function:
+
+```typescript
+// pages/home.ts
+export function render(el: HTMLElement, state: PopupState): void {
+  el.innerHTML = `
+    <section class="balance">...</section>
+    <section class="autospend">...</section>
+    <section class="pickups">...</section>
+  `
+  // bind event listeners
+}
+```
+
+### Router
+
+Hash-based routing (`#home`, `#payments`, `#transactions`, `#settings`):
+
+```typescript
+// router.ts
+const pages = { home, payments, transactions, settings }
+
+export function navigate(page: string, container: HTMLElement, state: PopupState) {
+  location.hash = page
+  const render = pages[page] ?? pages.home
+  render(container, state)
+}
+```
+
+### State lifecycle (fixes the flash bug)
+
+The popup shell shows a loading spinner by default. The app container is hidden until state arrives:
+
+```html
+<!-- popup.html -->
+<div id="loading" class="loading">
+  <div class="spinner"></div>
+  <span>Loading...</span>
+</div>
+<div id="app" hidden>
+  <!-- header tabs + page container -->
+</div>
+```
+
+```typescript
+// popup.ts
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('app')!
+  const state = await fetchState()       // wait for service worker
+  document.getElementById('loading')!.hidden = true
+  container.hidden = false               // swap spinner for content
+  renderHeader(state)
+  navigate(location.hash || 'home', container, state)
+  startPolling(state => updateActivePage(container, state))
+})
+```
+
+The spinner shows immediately on popup open (no flash of locked state). When the service worker responds, the spinner is replaced by the actual content. If the service worker is cold (needs to wake up), the spinner remains visible until ready.
+
+### Lock screen
+
+When `state.isUnlocked === false`, ALL pages show the lock screen instead of their content. This is handled in the router — if locked, render the unlock form regardless of which tab is active. On successful unlock, re-render the active page.
+
+## Page breakdown
+
+### Home
+- [KEEP] Balance display
+- [KEEP] Autospend health bar (extracted to `components/health-bar.ts`)
+- [KEEP] Pickup buttons (Medkit, Stimpak, Soul Sphere, New Game)
+- Lock/unlock button moves to header (always visible)
+
+### Payments
+- [NEW] Large slide-toggle: Send | Receive
+- **Send panel**: [KEEP] address input, amount input, send button, result display
+- **Receive panel**:
+  - [NEW] QR code of the wallet's identity key (or funding address)
+  - [NEW] Small toggle: Show Identity → identity key display
+  - [NEW] Small toggle: Legacy → root key / receive address display
+  - [KEEP] Copy buttons for identity key and address
+
+### Transactions
+- [NEW] `listActions` call to service worker (new message type: `listTransactions`)
+- [NEW] List of top 20 transactions, each showing:
+  - Amount: green `+` for received, red `-` for sent
+  - Status badge: confirmed/unconfirmed (like the status indicator)
+  - Description in light grey
+  - Txid: smaller font, blue, 🔍 prefix, links to WoC, highlight on hover
+  - No labels on any of these — use `title` attributes instead
+- [NEW] Pager control when >20 transactions exist
+- Requires new background handler: `case 'listTransactions'` → calls `backend.call('listActions', { labels: [], limit, offset, includeLabels: true })`
+
+### Settings
+- [KEEP] Difficulty dropdown (add "(Autospend limit)" label + sats in dropdown items)
+- [KEEP] Weapon dropdown
+- [KEEP] Tools section (Verify UTXOs button, UTXO Admin button)
+- [NEW] Recovery section:
+  - Seed display: first 4 chars `...` last 2 chars (from `getRootKeyHex()`)
+  - Export Wallet button → downloads IndexedDB as SQLite file
+  - Import Wallet button → uploads SQLite file, replaces IndexedDB
+- Recovery requires new background handlers: `adminExportWallet`, `adminImportWallet`
+
+## New message types needed
+
+| Message type | Direction | Purpose |
+|---|---|---|
+| `listTransactions` | popup → bg | Paginated tx list via `listActions` |
+| `adminExportWallet` | popup → bg | Dump IndexedDB → SQLite binary |
+| `adminImportWallet` | popup → bg | Load SQLite binary → IndexedDB |
+
+## Build changes
+
+Current build compiles `plugins/shared/ui/popup.ts` as a single IIFE entry point. The new structure has multiple files but they should still bundle into a single IIFE — tsup handles this if `popup.ts` imports the other modules.
+
+No changes to `plugins/build.ts` needed — `popup.ts` remains the entry point, it just imports from `state.ts`, `router.ts`, `pages/*.ts`, `components/*.ts`.
+
+## QR code dependency
+
+Need a lightweight QR code generator. Options:
+- `qr-creator` (~4KB, no dependencies, canvas-based)
+- `qrcode-generator` (~8KB)
+- Hand-roll using canvas (complex, not worth it)
+
+Add as a devDependency, bundled into the IIFE.
+
+## SQLite export/import dependency
+
+Need `sql.js` (SQLite compiled to WASM) for reading/writing SQLite files:
+- Export: read all IndexedDB object stores → write to SQLite tables → download as `.sqlite` file
+- Import: read `.sqlite` file → write to IndexedDB object stores → reload wallet
+
+This runs in the popup context (not service worker) since it needs file download/upload UI. The popup sends the data to the service worker for IndexedDB writes via the existing message protocol.
+
+Alternative: use the service worker + `chrome.downloads` API for export. Needs investigation.
+
+## Implementation sequence
+
+### Phase 1: Shell + Router + Home (gets the architecture right)
+1. Create `state.ts` — extract PopupState type, sendMessage, fetchState
+2. Create `router.ts` — hash-based routing
+3. Create `components/header.ts` — tab navigation
+4. Create `pages/home.ts` — balance, autospend, pickups (move from popup.ts)
+5. Rewrite `popup.html` — minimal shell with `<div id="app" hidden>`
+6. Rewrite `popup.ts` — init, router setup, state lifecycle (fixes flash bug)
+7. Rewrite `popup.css` — new layout with tab navigation
+
+### Phase 2: Remaining pages
+8. Create `pages/settings.ts` — tier, weapon, tools (move from popup.ts)
+9. Create `pages/payments.ts` — send (move from popup.ts) + receive (new)
+10. Create `components/qr.ts` — QR code rendering
+11. Create `pages/transactions.ts` — tx list + pager (new)
+12. Create `components/tx-row.ts` — transaction row component
+13. Add `listTransactions` handler to `background.ts`
+
+### Phase 3: Recovery
+14. Add `adminExportWallet` handler — IndexedDB → SQLite
+15. Add `adminImportWallet` handler — SQLite → IndexedDB
+16. Add recovery section to `pages/settings.ts`
+
+## Files to modify
+- `plugins/shared/ui/popup.html` — rewrite (minimal shell)
+- `plugins/shared/ui/popup.ts` — rewrite (tiny init)
+- `plugins/shared/ui/popup.css` — rewrite (new layout)
+- `plugins/shared/background.ts` — add `listTransactions`, `adminExportWallet`, `adminImportWallet` handlers
+
+## Files to create
+- `plugins/shared/ui/state.ts`
+- `plugins/shared/ui/router.ts`
+- `plugins/shared/ui/pages/home.ts`
+- `plugins/shared/ui/pages/payments.ts`
+- `plugins/shared/ui/pages/transactions.ts`
+- `plugins/shared/ui/pages/settings.ts`
+- `plugins/shared/ui/components/header.ts`
+- `plugins/shared/ui/components/tx-row.ts`
+- `plugins/shared/ui/components/health-bar.ts`
+- `plugins/shared/ui/components/qr.ts`
+
+## Verification
+- All existing functionality preserved (unlock, lock, balance, send, tier, weapon, pickups, verify UTXOs, UTXO admin)
+- Flash-of-locked-state bug fixed (hidden until state arrives)
+- Tab navigation works (hash-based, persists on popup reopen)
+- Transaction list populated from real wallet data
+- QR code renders on Payments → Receive
+- Build still produces single IIFE bundle per platform
+- `npm run build:all` succeeds
+- Extension loads and popup functions in Chrome

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.1",
       "hasInstallScript": true,
       "devDependencies": {
-        "@bsv/wallet-toolbox-client": "npm:@sgbett/wallet-toolbox-client@2.1.19-fix.1",
+        "@bsv/wallet-toolbox-client": "^2.1.21",
         "@types/chrome": "^0.1.38",
         "@types/express": "^5.0.6",
         "express": "^5.2.1",
@@ -30,10 +30,9 @@
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@bsv/wallet-toolbox-client": {
-      "name": "@sgbett/wallet-toolbox-client",
-      "version": "2.1.19-fix.1",
-      "resolved": "https://registry.npmjs.org/@sgbett/wallet-toolbox-client/-/wallet-toolbox-client-2.1.19-fix.1.tgz",
-      "integrity": "sha512-FMaV2q5Cz4yFydExE1F1acIBGuhsfqQWjZudhRTed2BxDeUmU2uaNlyBZultGmyj4zRFfGSCwTRWJfdN6iP2AQ==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-2.1.21.tgz",
+      "integrity": "sha512-wXUy12KpuKBhFlI14UsWydPFNn3zfyVUyQDrpSElmsgwpi9nlLFfuMBfWHdVMQXjhTDQFrZdb1qffkz+Fy0PIg==",
       "dev": true,
       "license": "SEE LICENSE IN license.md",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "bsv-x402",
       "version": "0.9.1",
       "hasInstallScript": true,
+      "dependencies": {
+        "qr-creator": "^1.0.0"
+      },
       "devDependencies": {
         "@bsv/wallet-toolbox-client": "npm:@sgbett/wallet-toolbox-client@2.1.19-fix.1",
         "@types/chrome": "^0.1.38",
@@ -2898,6 +2901,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qr-creator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
+      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,13 @@
       "name": "bsv-x402",
       "version": "0.9.1",
       "hasInstallScript": true,
-      "dependencies": {
-        "qr-creator": "^1.0.0"
-      },
       "devDependencies": {
         "@bsv/wallet-toolbox-client": "npm:@sgbett/wallet-toolbox-client@2.1.19-fix.1",
         "@types/chrome": "^0.1.38",
         "@types/express": "^5.0.6",
         "express": "^5.2.1",
         "patch-package": "^8.0.1",
+        "qr-creator": "^1.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.21.0",
         "typedoc": "^0.28.18",
@@ -2906,6 +2904,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
       "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "git+https://github.com/sgbett/bsv-x402.git"
   },
   "devDependencies": {
-    "@bsv/wallet-toolbox-client": "npm:@sgbett/wallet-toolbox-client@2.1.19-fix.1",
+    "@bsv/wallet-toolbox-client": "^2.1.21",
     "@types/chrome": "^0.1.38",
     "@types/express": "^5.0.6",
     "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "tsx": "^4.21.0",
     "typedoc": "^0.28.18",
     "typescript": "^5.0.0",
+    "qr-creator": "^1.0.0",
     "vitest": "^3.0.0"
   }
 }

--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -447,7 +447,7 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
     }
 
     case 'adminImportWallet': {
-      if (!wallet.isUnlocked()) throw new Error('Wallet is locked')
+      // No unlock check — import must work when locked (recovery scenario)
       const importPayload = message.payload as { json: string } | undefined
       if (!importPayload?.json) throw new Error('No backup data provided')
 
@@ -471,8 +471,8 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
         await importIndexedDB(dbName, stores)
       }
 
-      // Lock and require re-unlock to pick up new data
-      wallet.lock()
+      // Ensure locked state so re-unlock picks up imported data
+      if (wallet.isUnlocked()) wallet.lock()
       return { success: true, message: 'Wallet data imported. Please unlock to continue.' }
     }
 

--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -178,6 +178,7 @@ interface InternalMessage {
     | 'approvalResponse'
     | 'sendFunds'
     | 'verifyUtxos'
+    | 'listTransactions'
     | 'adminListOutputs'
     | 'adminAbortNosend'
   payload?: unknown
@@ -321,6 +322,21 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
       }
       const x402State = x402.getX402State()
       return { ...walletState, ...x402State, verifyResult }
+    }
+
+    case 'listTransactions': {
+      if (!wallet.isUnlocked()) throw new Error('Wallet is locked')
+      const backend = wallet.getBackend()
+      const payload = message.payload as { offset?: number } | undefined
+      const result = await backend.call('listActions', {
+        labels: [],
+        limit: 20,
+        offset: payload?.offset ?? 0,
+        includeLabels: true,
+        includeInputs: true,
+        includeOutputs: true,
+      }, 'self') as { totalActions: number; actions: Array<{ txid: string; satoshis: number; status: string; isOutgoing: boolean; description: string; labels?: string[] }> }
+      return { totalActions: result.totalActions, actions: result.actions }
     }
 
     case 'adminListOutputs': {

--- a/plugins/shared/background.ts
+++ b/plugins/shared/background.ts
@@ -181,6 +181,9 @@ interface InternalMessage {
     | 'listTransactions'
     | 'adminListOutputs'
     | 'adminAbortNosend'
+    | 'getRootKeyPreview'
+    | 'adminExportWallet'
+    | 'adminImportWallet'
   payload?: unknown
 }
 
@@ -408,6 +411,71 @@ async function handleInternalMessage(message: InternalMessage): Promise<Record<s
       return { aborted: result.totalActions, balance: walletState.balance }
     }
 
+    case 'getRootKeyPreview': {
+      if (!wallet.isUnlocked()) throw new Error('Wallet is locked')
+      const rootKey = wallet.getRootKeyHex()
+      if (!rootKey) throw new Error('Root key not available')
+      // Only expose first 4 + last 2 characters — never the full key
+      const preview = rootKey.slice(0, 4) + '...' + rootKey.slice(-2)
+      return { preview }
+    }
+
+    case 'adminExportWallet': {
+      if (!wallet.isUnlocked()) throw new Error('Wallet is locked')
+      const chain = wallet.getNetwork()
+      const dbName = `x402-wallet-${chain}`
+      const exportData = await exportIndexedDB(dbName)
+      // Also export chaintracks database
+      const chainTracksDbName = `chaintracks-${chain}net`
+      let chainTracksData: Record<string, unknown[]> | null = null
+      try {
+        chainTracksData = await exportIndexedDB(chainTracksDbName)
+      } catch {
+        // Chaintracks DB may not exist yet — not critical
+      }
+      const backup = {
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        chain,
+        databases: {
+          [dbName]: exportData,
+          ...(chainTracksData ? { [chainTracksDbName]: chainTracksData } : {}),
+        },
+      }
+      // Encode as JSON string (popup will handle the download)
+      return { json: JSON.stringify(backup) }
+    }
+
+    case 'adminImportWallet': {
+      if (!wallet.isUnlocked()) throw new Error('Wallet is locked')
+      const importPayload = message.payload as { json: string } | undefined
+      if (!importPayload?.json) throw new Error('No backup data provided')
+
+      let backup: {
+        version: number
+        chain: string
+        databases: Record<string, Record<string, unknown[]>>
+      }
+      try {
+        backup = JSON.parse(importPayload.json)
+      } catch {
+        throw new Error('Invalid backup file — could not parse JSON')
+      }
+
+      if (!backup.version || !backup.databases) {
+        throw new Error('Invalid backup file — missing version or databases')
+      }
+
+      // Import each database
+      for (const [dbName, stores] of Object.entries(backup.databases)) {
+        await importIndexedDB(dbName, stores)
+      }
+
+      // Lock and require re-unlock to pick up new data
+      wallet.lock()
+      return { success: true, message: 'Wallet data imported. Please unlock to continue.' }
+    }
+
     default:
       throw new Error(`Unknown message type: ${(message as InternalMessage).type}`)
   }
@@ -562,6 +630,98 @@ chrome.runtime.onInstalled.addListener((details) => {
     console.log(`x402: extension updated (reason: ${details.reason})`)
   }
 })
+
+// ---------------------------------------------------------------------------
+// IndexedDB export/import helpers — used for wallet backup/restore
+// ---------------------------------------------------------------------------
+
+/**
+ * Export all object stores from an IndexedDB database as a JSON-friendly object.
+ * Dynamically enumerates stores rather than hardcoding names.
+ */
+function exportIndexedDB(dbName: string): Promise<Record<string, unknown[]>> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(dbName)
+    request.onerror = () => reject(new Error(`Failed to open database: ${dbName}`))
+    request.onsuccess = () => {
+      const db = request.result
+      const storeNames = Array.from(db.objectStoreNames)
+      if (storeNames.length === 0) {
+        db.close()
+        resolve({})
+        return
+      }
+
+      const result: Record<string, unknown[]> = {}
+      let completed = 0
+
+      const tx = db.transaction(storeNames, 'readonly')
+      tx.onerror = () => {
+        db.close()
+        reject(new Error(`Transaction failed while reading ${dbName}`))
+      }
+
+      for (const storeName of storeNames) {
+        const store = tx.objectStore(storeName)
+        const getAllReq = store.getAll()
+        getAllReq.onsuccess = () => {
+          result[storeName] = getAllReq.result
+          completed++
+          if (completed === storeNames.length) {
+            db.close()
+            resolve(result)
+          }
+        }
+        getAllReq.onerror = () => {
+          db.close()
+          reject(new Error(`Failed to read store: ${storeName}`))
+        }
+      }
+    }
+  })
+}
+
+/**
+ * Import data into an IndexedDB database, clearing existing stores first.
+ * Opens the database (which must already exist with the correct schema)
+ * and replaces all data in the matching object stores.
+ */
+function importIndexedDB(dbName: string, stores: Record<string, unknown[]>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(dbName)
+    request.onerror = () => reject(new Error(`Failed to open database: ${dbName}`))
+    request.onsuccess = () => {
+      const db = request.result
+      const existingStores = Array.from(db.objectStoreNames)
+      const storeNames = Object.keys(stores).filter((name) => existingStores.includes(name))
+
+      if (storeNames.length === 0) {
+        db.close()
+        resolve()
+        return
+      }
+
+      const tx = db.transaction(storeNames, 'readwrite')
+      tx.onerror = () => {
+        db.close()
+        reject(new Error(`Transaction failed while writing to ${dbName}`))
+      }
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+
+      for (const storeName of storeNames) {
+        const store = tx.objectStore(storeName)
+        // Clear existing data before importing
+        store.clear()
+        for (const record of stores[storeName]) {
+          store.put(record)
+        }
+      }
+    }
+  })
+}
 
 // ---------------------------------------------------------------------------
 // Auto-lock after 60 minutes of idle

--- a/plugins/shared/ui/components/header.ts
+++ b/plugins/shared/ui/components/header.ts
@@ -8,10 +8,10 @@ import { sendMessage } from "../state";
 // ---------------------------------------------------------------------------
 
 const TABS = [
-  { id: "home", label: "Home" },
-  { id: "payments", label: "Payments" },
-  { id: "transactions", label: "Txns" },
-  { id: "settings", label: "Settings" },
+  { id: "home", label: "Home", requiresUnlock: false },
+  { id: "payments", label: "Payments", requiresUnlock: true },
+  { id: "transactions", label: "Txns", requiresUnlock: true },
+  { id: "settings", label: "Settings", requiresUnlock: false },
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -43,10 +43,14 @@ export function renderHeader(
 
   for (const tab of TABS) {
     const btn = document.createElement("button");
-    btn.className = `header-tab${tab.id === activePage ? " active" : ""}`;
+    const disabled = tab.requiresUnlock && !state.isUnlocked;
+    btn.className = `header-tab${tab.id === activePage ? " active" : ""}${disabled ? " disabled" : ""}`;
     btn.dataset.page = tab.id;
     btn.textContent = tab.label;
-    btn.addEventListener("click", () => onNavigate(tab.id));
+    btn.disabled = disabled;
+    if (!disabled) {
+      btn.addEventListener("click", () => onNavigate(tab.id));
+    }
     tabBar.appendChild(btn);
   }
 
@@ -97,14 +101,14 @@ export function updateHeader(
   state: PopupState,
   activePage: string,
 ): void {
-  // Update active tab
+  // Update active tab and disabled state
   const tabs = container.querySelectorAll<HTMLButtonElement>(".header-tab");
   for (const tab of tabs) {
-    if (tab.dataset.page === activePage) {
-      tab.classList.add("active");
-    } else {
-      tab.classList.remove("active");
-    }
+    const tabDef = TABS.find((t) => t.id === tab.dataset.page);
+    const disabled = tabDef?.requiresUnlock && !state.isUnlocked;
+    tab.classList.toggle("active", tab.dataset.page === activePage);
+    tab.classList.toggle("disabled", !!disabled);
+    tab.disabled = !!disabled;
   }
 
   // Update lock button

--- a/plugins/shared/ui/components/header.ts
+++ b/plugins/shared/ui/components/header.ts
@@ -1,0 +1,117 @@
+/// <reference types="chrome" />
+
+import type { PopupState } from "../state";
+import { sendMessage } from "../state";
+
+// ---------------------------------------------------------------------------
+// Tab definitions
+// ---------------------------------------------------------------------------
+
+const TABS = [
+  { id: "home", label: "Home" },
+  { id: "payments", label: "Payments" },
+  { id: "transactions", label: "Txns" },
+  { id: "settings", label: "Settings" },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the header bar with tab navigation and lock/unlock button.
+ *
+ * @param container - element to render the header into
+ * @param state - current popup state
+ * @param activePage - the currently active page id
+ * @param onNavigate - called when a tab is clicked with the page id
+ */
+export function renderHeader(
+  container: HTMLElement,
+  state: PopupState,
+  activePage: string,
+  onNavigate: (page: string) => void,
+): void {
+  container.innerHTML = "";
+
+  const nav = document.createElement("nav");
+  nav.className = "header-nav";
+
+  // Tab buttons
+  const tabBar = document.createElement("div");
+  tabBar.className = "header-tabs";
+
+  for (const tab of TABS) {
+    const btn = document.createElement("button");
+    btn.className = `header-tab${tab.id === activePage ? " active" : ""}`;
+    btn.dataset.page = tab.id;
+    btn.textContent = tab.label;
+    btn.addEventListener("click", () => onNavigate(tab.id));
+    tabBar.appendChild(btn);
+  }
+
+  // Lock/unlock button
+  const lockBtn = document.createElement("button");
+  lockBtn.id = "header-lock-btn";
+  lockBtn.className = `header-lock-btn ${state.isUnlocked ? "unlocked" : "locked"}`;
+  lockBtn.textContent = state.isUnlocked ? "Lock" : "Unlock";
+  lockBtn.title = state.isUnlocked ? "Lock wallet" : "Unlock wallet";
+
+  lockBtn.addEventListener("click", async () => {
+    if (state.isUnlocked) {
+      try {
+        const newState = await sendMessage<PopupState>("lock");
+        // Trigger a re-render by dispatching a custom event the shell
+        // can listen for, or let the caller handle via onNavigate.
+        // For simplicity, fire a custom event the shell listens to.
+        window.dispatchEvent(
+          new CustomEvent("x402-state-changed", { detail: newState }),
+        );
+      } catch (err) {
+        console.error("Lock failed:", err);
+      }
+    } else {
+      // When locked, clicking navigates to current page which triggers
+      // the lock screen via the router.
+      window.dispatchEvent(
+        new CustomEvent("x402-state-changed", { detail: state }),
+      );
+    }
+  });
+
+  nav.appendChild(tabBar);
+  nav.appendChild(lockBtn);
+  container.appendChild(nav);
+}
+
+// ---------------------------------------------------------------------------
+// Update (partial — avoids full re-render)
+// ---------------------------------------------------------------------------
+
+/**
+ * Update the header's active tab and lock button state without a full
+ * re-render. Call this after navigation or state changes.
+ */
+export function updateHeader(
+  container: HTMLElement,
+  state: PopupState,
+  activePage: string,
+): void {
+  // Update active tab
+  const tabs = container.querySelectorAll<HTMLButtonElement>(".header-tab");
+  for (const tab of tabs) {
+    if (tab.dataset.page === activePage) {
+      tab.classList.add("active");
+    } else {
+      tab.classList.remove("active");
+    }
+  }
+
+  // Update lock button
+  const lockBtn = container.querySelector("#header-lock-btn") as HTMLButtonElement | null;
+  if (lockBtn) {
+    lockBtn.className = `header-lock-btn ${state.isUnlocked ? "unlocked" : "locked"}`;
+    lockBtn.textContent = state.isUnlocked ? "Lock" : "Unlock";
+    lockBtn.title = state.isUnlocked ? "Lock wallet" : "Unlock wallet";
+  }
+}

--- a/plugins/shared/ui/components/health-bar.ts
+++ b/plugins/shared/ui/components/health-bar.ts
@@ -1,0 +1,41 @@
+import type { PopupState } from "../state";
+
+// ---------------------------------------------------------------------------
+// Health bar component — renders autospend balance as a percentage of tier cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the autospend health bar into the given container.
+ *
+ * Colour coding:
+ *  - Green (default): balance >= 50% of tier cap
+ *  - Yellow/orange ("low"): balance 25%-49%
+ *  - Red ("critical"): balance < 25%
+ *
+ * Preserves the existing percentage clamping logic from popup.ts.
+ */
+export function renderHealthBar(
+  container: HTMLElement,
+  state: PopupState,
+): void {
+  const pct =
+    state.tierCap > 0
+      ? Math.max(0, Math.min(100, (state.autospendBalance / state.tierCap) * 100))
+      : 0;
+
+  // Determine colour class
+  let colourClass = "";
+  if (pct < 25) colourClass = "critical";
+  else if (pct < 50) colourClass = "low";
+
+  container.innerHTML = `
+    <div class="health-bar">
+      <div class="health-bar-fill${colourClass ? ` ${colourClass}` : ""}"
+           style="width: ${pct}%"></div>
+    </div>
+    <div class="autospend-text">
+      <span class="autospend-value">${state.autospendBalance.toLocaleString()} sats</span>
+      <span class="autospend-cap">/ ${state.tierCap.toLocaleString()} sats</span>
+    </div>
+  `;
+}

--- a/plugins/shared/ui/components/qr.ts
+++ b/plugins/shared/ui/components/qr.ts
@@ -1,0 +1,33 @@
+import QrCreator from "qr-creator";
+
+// ---------------------------------------------------------------------------
+// QR code component — renders a QR code into a container element
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a QR code into the given container. Replaces any existing content.
+ *
+ * @param container - element to render the QR code into
+ * @param data      - the string to encode (identity key, address, etc.)
+ * @param size      - pixel size of the QR canvas (default 200)
+ */
+export function renderQR(
+  container: HTMLElement,
+  data: string,
+  size = 200,
+): void {
+  container.innerHTML = "";
+
+  QrCreator.render(
+    {
+      text: data,
+      size,
+      ecLevel: "M",
+      fill: "#e0e0e0",
+      background: "#1a1a2e",
+      radius: 0.4,
+      quiet: 1,
+    },
+    container,
+  );
+}

--- a/plugins/shared/ui/components/tx-row.ts
+++ b/plugins/shared/ui/components/tx-row.ts
@@ -44,7 +44,7 @@ export function renderTxRow(action: WalletAction, network: string): HTMLElement 
     amountEl.textContent = '0 sats'
     amountEl.classList.add('tx-amount-zero')
   } else if (action.isOutgoing) {
-    amountEl.textContent = `-${action.satoshis.toLocaleString()} sats`
+    amountEl.textContent = `${action.satoshis.toLocaleString()} sats`
     amountEl.classList.add('tx-amount-sent')
   } else {
     amountEl.textContent = `+${action.satoshis.toLocaleString()} sats`

--- a/plugins/shared/ui/components/tx-row.ts
+++ b/plugins/shared/ui/components/tx-row.ts
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------------
+// Transaction row component — renders a single WalletAction
+// ---------------------------------------------------------------------------
+
+interface WalletAction {
+  txid: string
+  satoshis: number
+  status: string
+  isOutgoing: boolean
+  description: string
+  labels?: string[]
+}
+
+interface StatusStyle {
+  label: string
+  className: string
+}
+
+const STATUS_MAP: Record<string, StatusStyle> = {
+  completed:   { label: 'confirmed',   className: 'status-confirmed' },
+  unprocessed: { label: 'unprocessed', className: 'status-grey' },
+  sending:     { label: 'sending',     className: 'status-amber' },
+  unproven:    { label: 'unproven',    className: 'status-amber' },
+  unsigned:    { label: 'unsigned',    className: 'status-grey' },
+  nosend:      { label: 'nosend',      className: 'status-blue' },
+  nonfinal:    { label: 'nonfinal',    className: 'status-grey' },
+  failed:      { label: 'failed',      className: 'status-failed' },
+}
+
+/**
+ * Render a single transaction row element.
+ *
+ * @param action - A WalletAction from the SDK
+ * @param network - 'mainnet' or 'testnet' for WoC link
+ */
+export function renderTxRow(action: WalletAction, network: string): HTMLElement {
+  const row = document.createElement('div')
+  row.className = 'tx-row'
+
+  // Amount
+  const amountEl = document.createElement('span')
+  amountEl.className = 'tx-amount'
+  if (action.satoshis === 0) {
+    amountEl.textContent = '0 sats'
+    amountEl.classList.add('tx-amount-zero')
+  } else if (action.isOutgoing) {
+    amountEl.textContent = `-${action.satoshis.toLocaleString()} sats`
+    amountEl.classList.add('tx-amount-sent')
+  } else {
+    amountEl.textContent = `+${action.satoshis.toLocaleString()} sats`
+    amountEl.classList.add('tx-amount-received')
+  }
+  amountEl.title = `${action.satoshis} satoshis`
+
+  // Status badge
+  const statusStyle = STATUS_MAP[action.status] ?? { label: action.status, className: 'status-grey' }
+  const badgeEl = document.createElement('span')
+  badgeEl.className = `tx-status-badge ${statusStyle.className}`
+  badgeEl.textContent = statusStyle.label
+  badgeEl.title = `Status: ${action.status}`
+
+  // Top line: amount + badge
+  const topLine = document.createElement('div')
+  topLine.className = 'tx-row-top'
+  topLine.appendChild(amountEl)
+  topLine.appendChild(badgeEl)
+
+  // Description
+  const descEl = document.createElement('div')
+  descEl.className = 'tx-description'
+  descEl.textContent = action.description || ''
+  descEl.title = action.description || ''
+
+  // Txid link to WoC
+  const txidEl = document.createElement('div')
+  txidEl.className = 'tx-txid'
+  if (action.txid) {
+    const wocBase = network === 'testnet'
+      ? 'https://test.whatsonchain.com/tx/'
+      : 'https://whatsonchain.com/tx/'
+    const link = document.createElement('a')
+    link.href = `${wocBase}${action.txid}`
+    link.target = '_blank'
+    link.rel = 'noopener noreferrer'
+    link.className = 'tx-txid-link'
+    link.textContent = `\u{1F50D} ${action.txid}`
+    link.title = action.txid
+    txidEl.appendChild(link)
+  }
+
+  row.appendChild(topLine)
+  row.appendChild(descEl)
+  row.appendChild(txidEl)
+
+  return row
+}

--- a/plugins/shared/ui/pages/home.ts
+++ b/plugins/shared/ui/pages/home.ts
@@ -1,0 +1,90 @@
+import type { PickupName } from "../../../../src/types";
+import type { PopupState } from "../state";
+import { sendMessage } from "../state";
+import { renderHealthBar } from "../components/health-bar";
+
+// ---------------------------------------------------------------------------
+// Home page — balance, autospend health bar, pickup buttons
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the Home page into the given container.
+ *
+ * Displays:
+ *  - Current balance in satoshis
+ *  - Autospend health bar (via the health-bar component)
+ *  - Pickup buttons: Medkit (+10%), Stimpak (+25%), Soul Sphere (+100%),
+ *    New Game (reset)
+ */
+export function render(container: HTMLElement, state: PopupState): void {
+  // Build static markup
+  container.innerHTML = `
+    <section class="balance">
+      <label>Balance</label>
+      <span class="balance-display">${formatBalance(state.balance)}</span>
+    </section>
+
+    <section class="autospend">
+      <label>Autospend Balance</label>
+      <div class="health-bar-container"></div>
+    </section>
+
+    <section class="pickups">
+      <label>Pickups (recharge autospend)</label>
+      <div class="pickup-buttons">
+        <button class="pickup-btn" data-pickup="Medkit">Medkit +10%</button>
+        <button class="pickup-btn" data-pickup="Stimpak">Stimpak +25%</button>
+        <button class="pickup-btn" data-pickup="Soul Sphere">Soul Sphere +100%</button>
+        <button class="pickup-btn new-game" data-pickup="New Game">New Game</button>
+      </div>
+    </section>
+  `;
+
+  // Render health bar into its container
+  const healthBarContainer = container.querySelector<HTMLElement>(
+    ".health-bar-container",
+  );
+  if (healthBarContainer) renderHealthBar(healthBarContainer, state);
+
+  // Bind pickup button handlers
+  container
+    .querySelectorAll<HTMLButtonElement>(".pickup-btn")
+    .forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const pickup = btn.dataset.pickup as PickupName | undefined;
+        if (!pickup) return;
+        try {
+          await sendMessage("pickup", { pickup });
+        } catch (err) {
+          alert(
+            `Pickup failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      });
+    });
+}
+
+/**
+ * Update the Home page in-place without rebuilding the entire DOM.
+ * Used by the polling cycle to refresh balance and health bar.
+ */
+export function update(container: HTMLElement, state: PopupState): void {
+  const balanceEl = container.querySelector<HTMLElement>(".balance-display");
+  if (balanceEl) balanceEl.textContent = formatBalance(state.balance);
+
+  const healthBarContainer = container.querySelector<HTMLElement>(
+    ".health-bar-container",
+  );
+  if (healthBarContainer) renderHealthBar(healthBarContainer, state);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Format a balance value, handling the undefined/initialising case. */
+function formatBalance(balance: number | undefined): string {
+  return balance !== undefined
+    ? `${balance.toLocaleString()} sats`
+    : "--- sats";
+}

--- a/plugins/shared/ui/pages/payments.ts
+++ b/plugins/shared/ui/pages/payments.ts
@@ -15,6 +15,8 @@ type ReceiveMode = "identity" | "address";
 /** Cached wallet info so we don't re-fetch on every toggle */
 let cachedIdentityKey = "";
 let cachedAddress = "";
+let fetchRetryCount = 0;
+const MAX_FETCH_RETRIES = 3;
 
 /**
  * Render the Payments page into the given container.
@@ -150,6 +152,7 @@ async function fetchWalletInfo(): Promise<void> {
     );
     if (result.identityKey) cachedIdentityKey = result.identityKey;
     if (result.address) cachedAddress = result.address;
+    fetchRetryCount = 0;
   } catch {
     // Wallet may be locked — data stays empty until next attempt
   }
@@ -184,9 +187,14 @@ function showReceiveData(container: HTMLElement, mode: ReceiveMode): void {
   const data = mode === "identity" ? cachedIdentityKey : cachedAddress;
 
   if (!data) {
+    if (fetchRetryCount >= MAX_FETCH_RETRIES) {
+      qrContainer.innerHTML = `<p class="qr-placeholder">Unavailable — wallet may be locked</p>`;
+      textEl.textContent = "";
+      return;
+    }
     qrContainer.innerHTML = `<p class="qr-placeholder">Loading...</p>`;
     textEl.textContent = "";
-    // Try fetching again
+    fetchRetryCount++;
     fetchWalletInfo().then(() => showReceiveData(container, mode));
     return;
   }

--- a/plugins/shared/ui/pages/payments.ts
+++ b/plugins/shared/ui/pages/payments.ts
@@ -1,0 +1,196 @@
+import type { PopupState } from "../state";
+import { sendMessage, copyToClipboard } from "../state";
+import { renderQR } from "../components/qr";
+
+// ---------------------------------------------------------------------------
+// Payments page — send and receive with QR codes
+// ---------------------------------------------------------------------------
+
+/** Active panel: send or receive */
+type Panel = "send" | "receive";
+
+/** What the receive QR displays */
+type ReceiveMode = "identity" | "address";
+
+/** Cached wallet info so we don't re-fetch on every toggle */
+let cachedIdentityKey = "";
+let cachedAddress = "";
+
+/**
+ * Render the Payments page into the given container.
+ */
+export function render(container: HTMLElement, _state: PopupState): void {
+  container.innerHTML = `
+    <div class="payments-toggle">
+      <button class="toggle-btn active" data-panel="send">Send</button>
+      <button class="toggle-btn" data-panel="receive">Receive</button>
+    </div>
+
+    <div class="payments-panel" id="send-panel">
+      <input type="text" class="input" id="pay-address" placeholder="Recipient address" autocomplete="off" />
+      <input type="number" class="input" id="pay-amount" placeholder="Amount (satoshis)" min="1" step="1" />
+      <button class="btn send-btn" id="pay-send-btn">Send</button>
+      <div class="send-result" id="pay-result"></div>
+    </div>
+
+    <div class="payments-panel hidden" id="receive-panel">
+      <div class="qr-container" id="receive-qr"></div>
+      <div class="receive-toggles">
+        <button class="receive-mode-btn active" data-mode="identity">Identity Key</button>
+        <button class="receive-mode-btn" data-mode="address">Legacy Address</button>
+      </div>
+      <div class="receive-display" id="receive-display">
+        <span class="receive-text" id="receive-text"></span>
+        <button class="copy-btn" id="receive-copy-btn">Copy</button>
+      </div>
+    </div>
+  `;
+
+  bindToggle(container);
+  bindSend(container);
+  bindReceive(container);
+
+  // Fetch wallet info eagerly so the receive panel is ready
+  fetchWalletInfo();
+}
+
+/**
+ * Update the Payments page in-place (called by polling cycle).
+ * Nothing needs updating — send results persist, receive data is cached.
+ */
+export function update(_container: HTMLElement, _state: PopupState): void {
+  // No periodic updates needed
+}
+
+// ---------------------------------------------------------------------------
+// Send / Receive toggle
+// ---------------------------------------------------------------------------
+
+function bindToggle(container: HTMLElement): void {
+  const buttons = container.querySelectorAll<HTMLButtonElement>(".toggle-btn");
+  const sendPanel = container.querySelector<HTMLElement>("#send-panel")!;
+  const receivePanel = container.querySelector<HTMLElement>("#receive-panel")!;
+
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const panel = btn.dataset.panel as Panel;
+
+      buttons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      if (panel === "send") {
+        sendPanel.classList.remove("hidden");
+        receivePanel.classList.add("hidden");
+      } else {
+        sendPanel.classList.add("hidden");
+        receivePanel.classList.remove("hidden");
+        // Render QR if we have data
+        showReceiveData(container, "identity");
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Send panel
+// ---------------------------------------------------------------------------
+
+function bindSend(container: HTMLElement): void {
+  const sendBtn = container.querySelector<HTMLButtonElement>("#pay-send-btn")!;
+  const addressInput = container.querySelector<HTMLInputElement>("#pay-address")!;
+  const amountInput = container.querySelector<HTMLInputElement>("#pay-amount")!;
+  const resultEl = container.querySelector<HTMLElement>("#pay-result")!;
+
+  sendBtn.addEventListener("click", async () => {
+    const address = addressInput.value.trim();
+    const amount = parseInt(amountInput.value, 10);
+
+    if (!address) {
+      resultEl.textContent = "Enter an address";
+      resultEl.className = "send-result error";
+      return;
+    }
+    if (!amount || amount <= 0) {
+      resultEl.textContent = "Enter a valid amount";
+      resultEl.className = "send-result error";
+      return;
+    }
+
+    sendBtn.disabled = true;
+    resultEl.textContent = "Sending...";
+    resultEl.className = "send-result";
+
+    try {
+      const result = await sendMessage<{ sendTxid: string }>(
+        "sendFunds",
+        { address, amount },
+      );
+      resultEl.textContent = `Sent! txid: ${result.sendTxid.slice(0, 12)}...`;
+      resultEl.className = "send-result success";
+      addressInput.value = "";
+      amountInput.value = "";
+    } catch (err) {
+      resultEl.textContent =
+        err instanceof Error ? err.message : String(err);
+      resultEl.className = "send-result error";
+    } finally {
+      sendBtn.disabled = false;
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Receive panel
+// ---------------------------------------------------------------------------
+
+async function fetchWalletInfo(): Promise<void> {
+  try {
+    const result = await sendMessage<{ identityKey?: string; address?: string }>(
+      "getAddress",
+    );
+    if (result.identityKey) cachedIdentityKey = result.identityKey;
+    if (result.address) cachedAddress = result.address;
+  } catch {
+    // Wallet may be locked — data stays empty until next attempt
+  }
+}
+
+function bindReceive(container: HTMLElement): void {
+  const modeButtons =
+    container.querySelectorAll<HTMLButtonElement>(".receive-mode-btn");
+
+  modeButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const mode = btn.dataset.mode as ReceiveMode;
+      modeButtons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      showReceiveData(container, mode);
+    });
+  });
+
+  const copyBtn = container.querySelector<HTMLButtonElement>("#receive-copy-btn")!;
+  copyBtn.addEventListener("click", async () => {
+    const text =
+      container.querySelector<HTMLElement>("#receive-text")?.textContent ?? "";
+    if (text) await copyToClipboard(text, copyBtn);
+  });
+}
+
+function showReceiveData(container: HTMLElement, mode: ReceiveMode): void {
+  const qrContainer = container.querySelector<HTMLElement>("#receive-qr");
+  const textEl = container.querySelector<HTMLElement>("#receive-text");
+  if (!qrContainer || !textEl) return;
+
+  const data = mode === "identity" ? cachedIdentityKey : cachedAddress;
+
+  if (!data) {
+    qrContainer.innerHTML = `<p class="qr-placeholder">Loading...</p>`;
+    textEl.textContent = "";
+    // Try fetching again
+    fetchWalletInfo().then(() => showReceiveData(container, mode));
+    return;
+  }
+
+  renderQR(qrContainer, data);
+  textEl.textContent = data;
+}

--- a/plugins/shared/ui/pages/settings.ts
+++ b/plugins/shared/ui/pages/settings.ts
@@ -1,0 +1,205 @@
+/// <reference types="chrome" />
+
+import type { TierName, WeaponName } from "../../../../src/types";
+import { TIER_CAPS, WEAPON_CAPS } from "../../../../src/autospend";
+import type { PopupState } from "../state";
+import { sendMessage } from "../state";
+
+// ---------------------------------------------------------------------------
+// Settings page — difficulty, weapon, tools, recovery
+// ---------------------------------------------------------------------------
+
+/** Ordered tier names for the dropdown. */
+const TIER_NAMES: TierName[] = [
+  "I'm Too Young to Die",
+  "Hey, Not Too Rough",
+  "Hurt Me Plenty",
+  "Ultra-Violence",
+  "Nightmare!",
+];
+
+/** Ordered weapon names for the dropdown. */
+const WEAPON_NAMES: WeaponName[] = [
+  "Fists",
+  "Chainsaw",
+  "Pistol",
+  "Shotgun",
+  "Super Shotgun",
+  "Chaingun",
+  "Rocket Launcher",
+  "Plasma Rifle",
+  "BFG9000",
+];
+
+/** Format a sats value for display in dropdown options. */
+function formatSats(sats: number): string {
+  if (!Number.isFinite(sats)) return "unlimited";
+  if (sats >= 100_000_000) return `${(sats / 100_000_000).toFixed(0)} BSV`;
+  if (sats >= 1_000_000) return `${(sats / 1_000_000).toFixed(1)}M sats`;
+  return `${sats.toLocaleString()} sats`;
+}
+
+/**
+ * Render the Settings page into the given container.
+ *
+ * Displays:
+ *  - Difficulty tier dropdown (autospend limit)
+ *  - Weapon dropdown (per-transaction cap)
+ *  - Tools: Verify UTXOs, UTXO Admin
+ *  - Recovery placeholder (deferred to Task 8)
+ */
+export function render(container: HTMLElement, state: PopupState): void {
+  const tierOptions = TIER_NAMES.map(
+    (name) =>
+      `<option value="${name}"${state.tier === name ? " selected" : ""}>${name} (${formatSats(TIER_CAPS[name])})</option>`,
+  ).join("");
+
+  const weaponOptions = WEAPON_NAMES.map(
+    (name) =>
+      `<option value="${name}"${state.weapon === name ? " selected" : ""}>${name} (${formatSats(WEAPON_CAPS[name])})</option>`,
+  ).join("");
+
+  container.innerHTML = `
+    <section class="settings-section">
+      <label>Difficulty <span class="label-hint">(Autospend limit)</span></label>
+      <select class="select" id="settings-tier-select">
+        ${tierOptions}
+      </select>
+    </section>
+
+    <section class="settings-section">
+      <label>Weapon <span class="label-hint">(Per-transaction cap)</span></label>
+      <select class="select" id="settings-weapon-select">
+        ${weaponOptions}
+      </select>
+    </section>
+
+    <section class="settings-section">
+      <label>Tools</label>
+      <div class="tools-buttons">
+        <button class="btn tool-btn" id="settings-verify-btn">Verify UTXOs</button>
+        <button class="btn tool-btn" id="settings-admin-btn">UTXO Admin</button>
+      </div>
+      <div id="settings-verify-result" class="verify-result"></div>
+    </section>
+
+    <section class="settings-section">
+      <label>Recovery</label>
+      <p class="placeholder">Coming soon</p>
+    </section>
+  `;
+
+  // --- Tier change ---
+  const tierSelect = container.querySelector<HTMLSelectElement>(
+    "#settings-tier-select",
+  )!;
+  tierSelect.addEventListener("change", async () => {
+    const tier = tierSelect.value as TierName;
+    try {
+      await sendMessage("setTier", { tier });
+    } catch (err) {
+      alert(
+        `Tier change failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  });
+
+  // --- Weapon change ---
+  const weaponSelect = container.querySelector<HTMLSelectElement>(
+    "#settings-weapon-select",
+  )!;
+  weaponSelect.addEventListener("change", async () => {
+    const weapon = weaponSelect.value as WeaponName;
+    try {
+      await sendMessage("setWeapon", { weapon });
+    } catch (err) {
+      alert(
+        `Weapon change failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  });
+
+  // --- Verify UTXOs ---
+  const verifyBtn = container.querySelector<HTMLButtonElement>(
+    "#settings-verify-btn",
+  )!;
+  const verifyResult = container.querySelector<HTMLDivElement>(
+    "#settings-verify-result",
+  )!;
+
+  verifyBtn.addEventListener("click", async () => {
+    verifyBtn.disabled = true;
+    verifyBtn.textContent = "Verifying...";
+    verifyResult.textContent = "";
+    verifyResult.className = "verify-result";
+
+    try {
+      const result = await sendMessage<PopupState & {
+        verifyResult?: { checked: number; relinquished: number; failed: number };
+      }>("verifyUtxos");
+
+      const vr = result.verifyResult;
+
+      if (!vr || vr.checked === 0) {
+        verifyResult.textContent = "No outputs to verify";
+        verifyResult.classList.add("verify-success");
+      } else if (vr.relinquished === 0 && vr.failed === 0) {
+        verifyResult.textContent = `Checked ${vr.checked} output${vr.checked !== 1 ? "s" : ""}: all valid`;
+        verifyResult.classList.add("verify-success");
+      } else {
+        const parts: string[] = [`Checked ${vr.checked}`];
+        if (vr.relinquished > 0) {
+          parts.push(
+            `released ${vr.relinquished} spent output${vr.relinquished !== 1 ? "s" : ""}`,
+          );
+        }
+        if (vr.failed > 0) {
+          parts.push(
+            `${vr.failed} lookup failure${vr.failed !== 1 ? "s" : ""}`,
+          );
+        }
+        verifyResult.textContent = parts.join(", ");
+        verifyResult.classList.add(
+          vr.failed > 0 ? "verify-error" : "verify-warning",
+        );
+      }
+    } catch (err) {
+      verifyResult.className = "verify-result verify-error";
+      verifyResult.textContent =
+        err instanceof Error ? err.message : String(err);
+    } finally {
+      verifyBtn.disabled = false;
+      verifyBtn.textContent = "Verify UTXOs";
+    }
+  });
+
+  // --- UTXO Admin ---
+  const adminBtn = container.querySelector<HTMLButtonElement>(
+    "#settings-admin-btn",
+  )!;
+  adminBtn.addEventListener("click", () => {
+    chrome.tabs.create({
+      url: chrome.runtime.getURL("ui/admin/utxos.html"),
+    });
+  });
+}
+
+/**
+ * Update the Settings page in-place without rebuilding the entire DOM.
+ * Used by the polling cycle to keep dropdown values in sync.
+ */
+export function update(container: HTMLElement, state: PopupState): void {
+  const tierSelect = container.querySelector<HTMLSelectElement>(
+    "#settings-tier-select",
+  );
+  if (tierSelect && tierSelect.value !== state.tier) {
+    tierSelect.value = state.tier;
+  }
+
+  const weaponSelect = container.querySelector<HTMLSelectElement>(
+    "#settings-weapon-select",
+  );
+  if (weaponSelect && weaponSelect.value !== state.weapon) {
+    weaponSelect.value = state.weapon;
+  }
+}

--- a/plugins/shared/ui/pages/settings.ts
+++ b/plugins/shared/ui/pages/settings.ts
@@ -59,17 +59,19 @@ export function render(container: HTMLElement, state: PopupState): void {
       `<option value="${name}"${state.weapon === name ? " selected" : ""}>${name} (${formatSats(WEAPON_CAPS[name])})</option>`,
   ).join("");
 
+  const locked = !state.isUnlocked;
+
   container.innerHTML = `
     <section class="settings-section">
       <label>Difficulty <span class="label-hint">(Autospend limit)</span></label>
-      <select class="select" id="settings-tier-select">
+      <select class="select" id="settings-tier-select"${locked ? " disabled" : ""}>
         ${tierOptions}
       </select>
     </section>
 
     <section class="settings-section">
       <label>Weapon <span class="label-hint">(Per-transaction cap)</span></label>
-      <select class="select" id="settings-weapon-select">
+      <select class="select" id="settings-weapon-select"${locked ? " disabled" : ""}>
         ${weaponOptions}
       </select>
     </section>
@@ -77,8 +79,8 @@ export function render(container: HTMLElement, state: PopupState): void {
     <section class="settings-section">
       <label>Tools</label>
       <div class="tools-buttons">
-        <button class="btn tool-btn" id="settings-verify-btn">Verify UTXOs</button>
-        <button class="btn tool-btn" id="settings-admin-btn">UTXO Admin</button>
+        <button class="btn tool-btn" id="settings-verify-btn"${locked ? " disabled" : ""}>Verify UTXOs</button>
+        <button class="btn tool-btn" id="settings-admin-btn"${locked ? " disabled" : ""}>UTXO Admin</button>
       </div>
       <div id="settings-verify-result" class="verify-result"></div>
     </section>
@@ -87,13 +89,14 @@ export function render(container: HTMLElement, state: PopupState): void {
       <label>Recovery</label>
       <div class="recovery-seed">
         <span class="recovery-seed-label">Seed:</span>
-        <span class="recovery-seed-value" id="settings-seed-preview">---</span>
+        <span class="recovery-seed-value" id="settings-seed-preview">${locked ? "locked" : "---"}</span>
       </div>
       <div class="recovery-buttons">
-        <button class="btn tool-btn" id="settings-export-btn">Export Wallet</button>
+        <button class="btn tool-btn" id="settings-export-btn"${locked ? " disabled" : ""}>Export Wallet</button>
         <button class="btn tool-btn" id="settings-import-btn">Import Wallet</button>
       </div>
       <div id="settings-recovery-status" class="recovery-status"></div>
+      ${state.isSetUp ? '<div class="recovery-warning">WARNING: Import will destroy existing wallet</div>' : ""}
       <input type="file" id="settings-import-input" accept=".json" style="display:none">
     </section>
   `;

--- a/plugins/shared/ui/pages/settings.ts
+++ b/plugins/shared/ui/pages/settings.ts
@@ -46,7 +46,7 @@ function formatSats(sats: number): string {
  *  - Difficulty tier dropdown (autospend limit)
  *  - Weapon dropdown (per-transaction cap)
  *  - Tools: Verify UTXOs, UTXO Admin
- *  - Recovery placeholder (deferred to Task 8)
+ *  - Recovery: seed preview, export, import
  */
 export function render(container: HTMLElement, state: PopupState): void {
   const tierOptions = TIER_NAMES.map(
@@ -85,7 +85,16 @@ export function render(container: HTMLElement, state: PopupState): void {
 
     <section class="settings-section">
       <label>Recovery</label>
-      <p class="placeholder">Coming soon</p>
+      <div class="recovery-seed">
+        <span class="recovery-seed-label">Seed:</span>
+        <span class="recovery-seed-value" id="settings-seed-preview">---</span>
+      </div>
+      <div class="recovery-buttons">
+        <button class="btn tool-btn" id="settings-export-btn">Export Wallet</button>
+        <button class="btn tool-btn" id="settings-import-btn">Import Wallet</button>
+      </div>
+      <div id="settings-recovery-status" class="recovery-status"></div>
+      <input type="file" id="settings-import-input" accept=".json" style="display:none">
     </section>
   `;
 
@@ -181,6 +190,122 @@ export function render(container: HTMLElement, state: PopupState): void {
     chrome.tabs.create({
       url: chrome.runtime.getURL("ui/admin/utxos.html"),
     });
+  });
+
+  // --- Seed preview ---
+  const seedPreview = container.querySelector<HTMLSpanElement>(
+    "#settings-seed-preview",
+  )!;
+
+  if (state.isUnlocked) {
+    sendMessage<{ preview: string }>("getRootKeyPreview")
+      .then((result) => {
+        seedPreview.textContent = result.preview;
+      })
+      .catch(() => {
+        seedPreview.textContent = "unavailable";
+      });
+  } else {
+    seedPreview.textContent = "locked";
+  }
+
+  // --- Recovery status helper ---
+  const recoveryStatus = container.querySelector<HTMLDivElement>(
+    "#settings-recovery-status",
+  )!;
+
+  function showRecoveryStatus(
+    text: string,
+    type: "success" | "error" | "info",
+  ): void {
+    recoveryStatus.textContent = text;
+    recoveryStatus.className = `recovery-status recovery-${type}`;
+  }
+
+  // --- Export Wallet ---
+  const exportBtn = container.querySelector<HTMLButtonElement>(
+    "#settings-export-btn",
+  )!;
+  exportBtn.addEventListener("click", async () => {
+    exportBtn.disabled = true;
+    exportBtn.textContent = "Exporting...";
+    recoveryStatus.textContent = "";
+    recoveryStatus.className = "recovery-status";
+
+    try {
+      const result = await sendMessage<{ json: string }>("adminExportWallet");
+      // Trigger download
+      const blob = new Blob([result.json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const date = new Date().toISOString().slice(0, 10);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `x402-wallet-backup-${date}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      showRecoveryStatus("Backup downloaded", "success");
+    } catch (err) {
+      showRecoveryStatus(
+        `Export failed: ${err instanceof Error ? err.message : String(err)}`,
+        "error",
+      );
+    } finally {
+      exportBtn.disabled = false;
+      exportBtn.textContent = "Export Wallet";
+    }
+  });
+
+  // --- Import Wallet ---
+  const importBtn = container.querySelector<HTMLButtonElement>(
+    "#settings-import-btn",
+  )!;
+  const importInput = container.querySelector<HTMLInputElement>(
+    "#settings-import-input",
+  )!;
+
+  importBtn.addEventListener("click", () => {
+    recoveryStatus.textContent = "";
+    recoveryStatus.className = "recovery-status";
+    importInput.click();
+  });
+
+  importInput.addEventListener("change", async () => {
+    const file = importInput.files?.[0];
+    if (!file) return;
+
+    // Confirmation dialog — importing is destructive
+    const confirmed = confirm(
+      "This will replace your current wallet data. Are you sure you want to continue?",
+    );
+    if (!confirmed) {
+      importInput.value = "";
+      return;
+    }
+
+    importBtn.disabled = true;
+    importBtn.textContent = "Importing...";
+
+    try {
+      const json = await file.text();
+      const result = await sendMessage<{ success: boolean; message: string }>(
+        "adminImportWallet",
+        { json },
+      );
+      showRecoveryStatus(result.message, "success");
+      // Reload the popup after a short delay to pick up the locked state
+      setTimeout(() => location.reload(), 1500);
+    } catch (err) {
+      showRecoveryStatus(
+        `Import failed: ${err instanceof Error ? err.message : String(err)}`,
+        "error",
+      );
+    } finally {
+      importBtn.disabled = false;
+      importBtn.textContent = "Import Wallet";
+      importInput.value = "";
+    }
   });
 }
 

--- a/plugins/shared/ui/pages/transactions.ts
+++ b/plugins/shared/ui/pages/transactions.ts
@@ -1,0 +1,123 @@
+import type { PopupState } from '../state'
+import { sendMessage } from '../state'
+import { renderTxRow } from '../components/tx-row'
+
+// ---------------------------------------------------------------------------
+// Transactions page — paginated list of wallet actions
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 20
+
+interface ListTransactionsResult {
+  totalActions: number
+  actions: Array<{
+    txid: string
+    satoshis: number
+    status: string
+    isOutgoing: boolean
+    description: string
+    labels?: string[]
+  }>
+}
+
+/**
+ * Render the Transactions page into the given container.
+ *
+ * Fetches the first page of actions from the background service worker
+ * and displays them as a paginated list.
+ */
+export function render(container: HTMLElement, state: PopupState): void {
+  let currentOffset = 0
+
+  container.innerHTML = `
+    <div class="tx-loading">Loading transactions\u2026</div>
+  `
+
+  fetchAndRender(container, state, currentOffset, (newOffset) => {
+    currentOffset = newOffset
+  })
+}
+
+function fetchAndRender(
+  container: HTMLElement,
+  state: PopupState,
+  offset: number,
+  setOffset: (o: number) => void,
+): void {
+  container.innerHTML = `<div class="tx-loading">Loading transactions\u2026</div>`
+
+  sendMessage<ListTransactionsResult>('listTransactions', { offset })
+    .then((result) => {
+      renderPage(container, state, result, offset, setOffset)
+    })
+    .catch((err) => {
+      container.innerHTML = `
+        <div class="tx-empty">
+          Failed to load transactions: ${err instanceof Error ? err.message : String(err)}
+        </div>
+      `
+    })
+}
+
+function renderPage(
+  container: HTMLElement,
+  state: PopupState,
+  result: ListTransactionsResult,
+  offset: number,
+  setOffset: (o: number) => void,
+): void {
+  container.innerHTML = ''
+
+  if (result.totalActions === 0) {
+    container.innerHTML = `<div class="tx-empty">No transactions yet</div>`
+    return
+  }
+
+  // Transaction list
+  const listEl = document.createElement('div')
+  listEl.className = 'tx-list'
+
+  for (const action of result.actions) {
+    listEl.appendChild(renderTxRow(action, state.network))
+  }
+
+  container.appendChild(listEl)
+
+  // Pager
+  const totalPages = Math.ceil(result.totalActions / PAGE_SIZE)
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+
+  if (totalPages > 1) {
+    const pagerEl = document.createElement('div')
+    pagerEl.className = 'tx-pager'
+
+    const prevBtn = document.createElement('button')
+    prevBtn.className = 'tx-pager-btn'
+    prevBtn.textContent = 'Previous'
+    prevBtn.disabled = currentPage <= 1
+    prevBtn.addEventListener('click', () => {
+      const newOffset = Math.max(0, offset - PAGE_SIZE)
+      setOffset(newOffset)
+      fetchAndRender(container, state, newOffset, setOffset)
+    })
+
+    const pageInfo = document.createElement('span')
+    pageInfo.className = 'tx-pager-info'
+    pageInfo.textContent = `Page ${currentPage} of ${totalPages}`
+
+    const nextBtn = document.createElement('button')
+    nextBtn.className = 'tx-pager-btn'
+    nextBtn.textContent = 'Next'
+    nextBtn.disabled = currentPage >= totalPages
+    nextBtn.addEventListener('click', () => {
+      const newOffset = offset + PAGE_SIZE
+      setOffset(newOffset)
+      fetchAndRender(container, state, newOffset, setOffset)
+    })
+
+    pagerEl.appendChild(prevBtn)
+    pagerEl.appendChild(pageInfo)
+    pagerEl.appendChild(nextBtn)
+    container.appendChild(pagerEl)
+  }
+}

--- a/plugins/shared/ui/pages/transactions.ts
+++ b/plugins/shared/ui/pages/transactions.ts
@@ -51,11 +51,11 @@ function fetchAndRender(
       renderPage(container, state, result, offset, setOffset)
     })
     .catch((err) => {
-      container.innerHTML = `
-        <div class="tx-empty">
-          Failed to load transactions: ${err instanceof Error ? err.message : String(err)}
-        </div>
-      `
+      const errorEl = document.createElement('div')
+      errorEl.className = 'tx-empty'
+      errorEl.textContent = `Failed to load transactions: ${err instanceof Error ? err.message : String(err)}`
+      container.innerHTML = ''
+      container.appendChild(errorEl)
     })
 }
 

--- a/plugins/shared/ui/pages/transactions.ts
+++ b/plugins/shared/ui/pages/transactions.ts
@@ -77,7 +77,8 @@ function renderPage(
   const listEl = document.createElement('div')
   listEl.className = 'tx-list'
 
-  for (const action of result.actions) {
+  // Show newest first
+  for (const action of [...result.actions].reverse()) {
     listEl.appendChild(renderTxRow(action, state.network))
   }
 

--- a/plugins/shared/ui/popup.css
+++ b/plugins/shared/ui/popup.css
@@ -8,40 +8,147 @@ body {
   font-size: 14px;
 }
 
+/* ---------------------------------------------------------------------------
+   Loading spinner — visible by default until state arrives
+   --------------------------------------------------------------------------- */
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  gap: 12px;
+  color: #888;
+  font-size: 13px;
+}
+
+.spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid #2a2a4a;
+  border-top-color: #00d4aa;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ---------------------------------------------------------------------------
+   App shell
+   --------------------------------------------------------------------------- */
+
 .popup { padding: 16px; }
 
-header {
+/* ---------------------------------------------------------------------------
+   Header — tab navigation + lock button
+   --------------------------------------------------------------------------- */
+
+.header-nav {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   margin-bottom: 16px;
   padding-bottom: 12px;
   border-bottom: 1px solid #2a2a4a;
 }
 
-h1 { font-size: 16px; font-weight: 600; color: #fff; }
-
-.status {
-  font-size: 12px;
-  padding: 3px 10px;
-  border-radius: 12px;
-  font-weight: 500;
+.header-tabs {
+  display: flex;
+  flex: 1;
+  gap: 2px;
 }
-.status.locked { background: #3a2020; color: #f06060; }
-.status.unlocked { background: #1a3a2a; color: #00d4aa; }
 
-section { margin-bottom: 14px; }
-
-label {
-  display: block;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+.header-tab {
+  background: none;
+  border: none;
   color: #888;
-  margin-bottom: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
 }
 
-input {
+.header-tab:hover {
+  color: #e0e0e0;
+  background: #2a2a4a;
+}
+
+.header-tab.active {
+  color: #00d4aa;
+  background: #16213e;
+}
+
+.header-lock-btn {
+  border: none;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  margin-left: 8px;
+}
+
+.header-lock-btn:hover { opacity: 0.85; }
+
+.header-lock-btn.unlocked {
+  background: #e04050;
+  color: #fff;
+}
+
+.header-lock-btn.locked {
+  background: #00ffbb;
+  color: #1a1a2e;
+}
+
+/* ---------------------------------------------------------------------------
+   Page container
+   --------------------------------------------------------------------------- */
+
+#page-container {
+  min-height: 120px;
+}
+
+/* ---------------------------------------------------------------------------
+   Lock screen
+   --------------------------------------------------------------------------- */
+
+.lock-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  gap: 16px;
+}
+
+.lock-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.lock-form {
+  width: 100%;
+  max-width: 280px;
+}
+
+.lock-error {
+  color: #f06060;
+  font-size: 12px;
+  margin-top: 4px;
+  min-height: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   Common form elements
+   --------------------------------------------------------------------------- */
+
+.input {
   width: 100%;
   padding: 8px 10px;
   background: #16213e;
@@ -52,60 +159,7 @@ input {
   outline: none;
   margin-bottom: 8px;
 }
-input:focus { border-color: #00d4aa; }
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
-input[type="number"] { -moz-appearance: textfield; }
-input:last-child { margin-bottom: 0px; }
-
-.balance span, #balance-display {
-  font-size: 20px;
-  font-weight: 700;
-  color: #00d4aa;
-}
-
-.tier-name {
-  display: block;
-  font-size: 13px;
-  margin-bottom: 6px;
-  color: #ccc;
-}
-
-#tier-select {
-  width: 100%;
-  padding: 8px 10px;
-  background: #16213e;
-  color: #e0e0e0;
-  border: 1px solid #2a2a4a;
-  border-radius: 6px;
-  font-size: 13px;
-  cursor: pointer;
-  outline: none;
-}
-#tier-select:focus { border-color: #00d4aa; }
-
-.limits-summary {
-  font-size: 13px;
-  color: #999;
-  padding: 8px;
-  background: #16213e;
-  border-radius: 6px;
-}
-
-#indicator-mode-select {
-  width: 100%;
-  padding: 8px 10px;
-  background: #16213e;
-  color: #e0e0e0;
-  border: 1px solid #2a2a4a;
-  border-radius: 6px;
-  font-size: 13px;
-  cursor: pointer;
-  outline: none;
-}
-#indicator-mode-select:focus { border-color: #00d4aa; }
-
-.actions { margin: 16px 0 12px; }
+.input:focus { border-color: #00d4aa; }
 
 .btn {
   width: 100%;
@@ -118,71 +172,40 @@ input:last-child { margin-bottom: 0px; }
   opacity: 0.85;
   transition: opacity 0.15s;
 }
-
 .btn:hover { opacity: 1; }
 
-.lock-btn.locked { background: #00ffbb; color: #1a1a2e; }
-.lock-btn.unlocked { background: #e04050; color: #fff; }
-
-.send-btn { background: #00bbff; color: #1a1a2e; }
-.verify-btn { background: #ffbb00; color: #1a1a2e; }
-
-.setup-container { margin: 12px 0; }
-
+.unlock-btn { background: #00ffbb; color: #1a1a2e; }
 .setup-btn { background: #00ffbb; color: #1a1a2e; }
 
-.address-section { margin-bottom: 14px; }
-.address-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  background: #16213e;
-  border-radius: 6px;
-  padding: 6px 8px;
-}
-.address-text {
-  flex: 1;
-  font-family: 'Courier New', monospace;
+/* ---------------------------------------------------------------------------
+   Sections and labels
+   --------------------------------------------------------------------------- */
+
+section { margin-bottom: 14px; }
+
+label {
+  display: block;
   font-size: 11px;
-  color: #ccc;
-  word-break: break-all;
-  user-select: all;
-}
-.copy-btn {
-  background: #2a2a4a;
-  border: none;
-  color: #e0e0e0;
-  padding: 4px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 11px;
-  white-space: nowrap;
-}
-.copy-btn:hover { background: #00d4aa; color: #1a1a2e; }
-
-.unlock-form { margin-bottom: 8px; }
-
-.unlock-error {
-  color: #f06060;
-  font-size: 12px;
-  margin-top: 4px;
-  min-height: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #888;
+  margin-bottom: 4px;
 }
 
-/* Verify UTXO result states */
-.verify-result { font-size: 12px; margin-top: 4px; min-height: 0; }
-.verify-result.verify-success { color: #00d4aa; }
-.verify-result.verify-warning { color: #f1c40f; }
-.verify-result.verify-error { color: #e74c3c; }
+/* ---------------------------------------------------------------------------
+   Balance display
+   --------------------------------------------------------------------------- */
 
-footer {
-  text-align: center;
-  padding-top: 8px;
-  border-top: 1px solid #2a2a4a;
+.balance span, .balance-display {
+  font-size: 20px;
+  font-weight: 700;
+  color: #00d4aa;
 }
-.footer-text { color: #555; font-size: 12px; }
 
-/* Autospend health bar */
+/* ---------------------------------------------------------------------------
+   Autospend health bar
+   --------------------------------------------------------------------------- */
+
 .health-bar {
   width: 100%;
   height: 16px;
@@ -191,34 +214,43 @@ footer {
   overflow: hidden;
   margin: 6px 0;
 }
+
 .health-bar-fill {
   height: 100%;
   background: linear-gradient(to right, #00d4aa, #00ffaa);
   transition: width 0.3s ease;
   width: 100%;
 }
+
 .health-bar-fill.low {
   background: linear-gradient(to right, #f1c40f, #e67e22);
 }
+
 .health-bar-fill.critical {
   background: linear-gradient(to right, #e74c3c, #c0392b);
 }
+
 .autospend-text {
   font-size: 12px;
   color: #888;
   text-align: right;
 }
-.autospend-text #autospend-value {
+
+.autospend-value {
   color: #e0e0e0;
 }
 
-/* Pickup buttons */
+/* ---------------------------------------------------------------------------
+   Pickup buttons
+   --------------------------------------------------------------------------- */
+
 .pickup-buttons {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6px;
   margin-top: 4px;
 }
+
 .pickup-btn {
   padding: 8px 4px;
   background: #2a2a4a;
@@ -229,23 +261,37 @@ footer {
   cursor: pointer;
   transition: background 0.15s;
 }
+
 .pickup-btn:hover { background: #3a3a5a; }
+
 .pickup-btn.new-game {
   background: #00d4aa;
   color: #1a1a2e;
   font-weight: 600;
 }
+
 .pickup-btn.new-game:hover { background: #00ffaa; }
 
-/* Weapon section */
-.weapon select,
-.tier select {
-  width: 100%;
-  padding: 6px 8px;
-  background: #2a2a4a;
-  color: #e0e0e0;
-  border: 1px solid #3a3a5a;
-  border-radius: 6px;
-  font-size: 12px;
-  margin-top: 4px;
+/* ---------------------------------------------------------------------------
+   Placeholder (coming soon)
+   --------------------------------------------------------------------------- */
+
+.placeholder {
+  text-align: center;
+  padding: 40px 16px;
+  color: #555;
+  font-size: 14px;
+  font-style: italic;
 }
+
+/* ---------------------------------------------------------------------------
+   Footer
+   --------------------------------------------------------------------------- */
+
+footer {
+  text-align: center;
+  padding-top: 8px;
+  border-top: 1px solid #2a2a4a;
+}
+
+.footer-text { color: #555; font-size: 12px; }

--- a/plugins/shared/ui/popup.css
+++ b/plugins/shared/ui/popup.css
@@ -1,4 +1,5 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
+[hidden] { display: none !important; }
 
 body {
   width: 400px;
@@ -80,6 +81,17 @@ body {
 .header-tab.active {
   color: #00d4aa;
   background: #16213e;
+}
+
+.header-tab.disabled {
+  color: #444;
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.header-tab.disabled:hover {
+  color: #444;
+  background: none;
 }
 
 .header-lock-btn {
@@ -515,6 +527,12 @@ label {
 .recovery-status.recovery-success { color: #00d4aa; }
 .recovery-status.recovery-error { color: #e74c3c; }
 .recovery-status.recovery-info { color: #3498db; }
+
+.recovery-warning {
+  font-size: 11px;
+  color: #e04050;
+  margin-top: 6px;
+}
 
 /* ---------------------------------------------------------------------------
    Transactions page

--- a/plugins/shared/ui/popup.css
+++ b/plugins/shared/ui/popup.css
@@ -474,6 +474,49 @@ label {
 }
 
 /* ---------------------------------------------------------------------------
+   Recovery section
+   --------------------------------------------------------------------------- */
+
+.recovery-seed {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #16213e;
+  border: 1px solid #2a2a4a;
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+}
+
+.recovery-seed-label {
+  font-size: 12px;
+  color: #888;
+}
+
+.recovery-seed-value {
+  font-size: 13px;
+  font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+  color: #e0e0e0;
+  letter-spacing: 0.5px;
+}
+
+.recovery-buttons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.recovery-status {
+  font-size: 12px;
+  margin-top: 6px;
+  min-height: 0;
+}
+.recovery-status.recovery-success { color: #00d4aa; }
+.recovery-status.recovery-error { color: #e74c3c; }
+.recovery-status.recovery-info { color: #3498db; }
+
+/* ---------------------------------------------------------------------------
    Transactions page
    --------------------------------------------------------------------------- */
 

--- a/plugins/shared/ui/popup.css
+++ b/plugins/shared/ui/popup.css
@@ -331,10 +331,255 @@ label {
 .verify-result.verify-error { color: #e74c3c; }
 
 /* ---------------------------------------------------------------------------
+   Payments page — send/receive toggle, send form, QR receive
+   --------------------------------------------------------------------------- */
+
+.payments-toggle {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 14px;
+}
+
+.toggle-btn {
+  flex: 1;
+  padding: 10px;
+  background: #2a2a4a;
+  color: #888;
+  border: 1px solid #3a3a5a;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.toggle-btn:hover {
+  color: #e0e0e0;
+  background: #3a3a5a;
+}
+
+.toggle-btn.active {
+  background: #00d4aa;
+  color: #1a1a2e;
+  border-color: #00d4aa;
+}
+
+.payments-panel.hidden { display: none; }
+
+.send-btn {
+  background: #00d4aa;
+  color: #1a1a2e;
+}
+
+.send-result {
+  font-size: 12px;
+  margin-top: 8px;
+  min-height: 0;
+  word-break: break-all;
+}
+.send-result.success { color: #00d4aa; }
+.send-result.error { color: #e74c3c; }
+
+.qr-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 14px;
+}
+
+.qr-container canvas {
+  border-radius: 8px;
+}
+
+.qr-placeholder {
+  color: #555;
+  font-size: 13px;
+  font-style: italic;
+  text-align: center;
+  padding: 40px 0;
+}
+
+.receive-toggles {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.receive-mode-btn {
+  flex: 1;
+  padding: 6px;
+  background: #2a2a4a;
+  color: #888;
+  border: 1px solid #3a3a5a;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.receive-mode-btn:hover {
+  color: #e0e0e0;
+  background: #3a3a5a;
+}
+
+.receive-mode-btn.active {
+  background: #16213e;
+  color: #00d4aa;
+  border-color: #00d4aa;
+}
+
+.receive-display {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  background: #16213e;
+  border: 1px solid #2a2a4a;
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+
+.receive-text {
+  flex: 1;
+  font-size: 11px;
+  font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+  color: #e0e0e0;
+  word-break: break-all;
+  line-height: 1.4;
+}
+
+.copy-btn {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  background: #2a2a4a;
+  color: #e0e0e0;
+  border: 1px solid #3a3a5a;
+  border-radius: 4px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.copy-btn:hover { background: #3a3a5a; }
+
+/* ---------------------------------------------------------------------------
    Placeholder (coming soon)
    --------------------------------------------------------------------------- */
 
 .placeholder {
+  text-align: center;
+  padding: 40px 16px;
+  color: #555;
+  font-size: 14px;
+  font-style: italic;
+}
+
+/* ---------------------------------------------------------------------------
+   Transactions page
+   --------------------------------------------------------------------------- */
+
+.tx-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tx-row {
+  padding: 8px 10px;
+  background: #16213e;
+  border-radius: 6px;
+}
+
+.tx-row-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 2px;
+}
+
+.tx-amount {
+  font-size: 14px;
+  font-weight: 600;
+}
+.tx-amount-received { color: #00d4aa; }
+.tx-amount-sent { color: #e04050; }
+.tx-amount-zero { color: #888; }
+
+.tx-status-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+.status-confirmed { background: #0a3a2a; color: #00d4aa; }
+.status-amber { background: #3a2a0a; color: #f1c40f; }
+.status-blue { background: #0a2a3a; color: #3498db; }
+.status-failed { background: #3a0a0a; color: #e04050; }
+.status-grey { background: #2a2a3a; color: #888; }
+
+.tx-description {
+  font-size: 12px;
+  color: #888;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 2px;
+}
+
+.tx-txid {
+  font-size: 11px;
+  font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tx-txid-link {
+  color: #3498db;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.tx-txid-link:hover { color: #5dade2; }
+
+.tx-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #2a2a4a;
+}
+
+.tx-pager-btn {
+  padding: 6px 14px;
+  background: #2a2a4a;
+  color: #e0e0e0;
+  border: 1px solid #3a3a5a;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.tx-pager-btn:hover:not(:disabled) { background: #3a3a5a; }
+.tx-pager-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.tx-pager-info {
+  font-size: 12px;
+  color: #888;
+}
+
+.tx-loading {
+  text-align: center;
+  padding: 40px 16px;
+  color: #888;
+  font-size: 13px;
+}
+
+.tx-empty {
   text-align: center;
   padding: 40px 16px;
   color: #555;

--- a/plugins/shared/ui/popup.css
+++ b/plugins/shared/ui/popup.css
@@ -273,6 +273,64 @@ label {
 .pickup-btn.new-game:hover { background: #00ffaa; }
 
 /* ---------------------------------------------------------------------------
+   Settings page
+   --------------------------------------------------------------------------- */
+
+.settings-section { margin-bottom: 16px; }
+
+.label-hint {
+  text-transform: none;
+  letter-spacing: 0;
+  color: #666;
+  font-style: italic;
+}
+
+.select {
+  width: 100%;
+  padding: 8px 10px;
+  background: #16213e;
+  color: #e0e0e0;
+  border: 1px solid #2a2a4a;
+  border-radius: 6px;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23888'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.select:focus { border-color: #00d4aa; }
+
+.tools-buttons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.tool-btn {
+  padding: 8px 4px;
+  background: #2a2a4a;
+  color: #e0e0e0;
+  border: 1px solid #3a3a5a;
+  font-size: 12px;
+  font-weight: 500;
+}
+.tool-btn:hover { background: #3a3a5a; }
+.tool-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.verify-result {
+  font-size: 12px;
+  margin-top: 6px;
+  min-height: 0;
+}
+.verify-result.verify-success { color: #00d4aa; }
+.verify-result.verify-warning { color: #f1c40f; }
+.verify-result.verify-error { color: #e74c3c; }
+
+/* ---------------------------------------------------------------------------
    Placeholder (coming soon)
    --------------------------------------------------------------------------- */
 

--- a/plugins/shared/ui/popup.html
+++ b/plugins/shared/ui/popup.html
@@ -7,126 +7,16 @@
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
-  <div class="popup">
-    <header>
-      <h1>bsv-x402</h1>
-      <span id="status-indicator" class="status locked">Locked</span>
-    </header>
+  <!-- Loading spinner — visible by default, hidden once state arrives -->
+  <div id="loading" class="loading">
+    <div class="spinner"></div>
+    <span>Loading...</span>
+  </div>
 
-    <!-- ============================================================
-         Wallet panel — only shown when built-in backend is active.
-         This entire section can be removed when a proper wallet UI
-         package exists. It MUST NOT reference x402 concerns.
-         ============================================================ -->
-    <div id="wallet-panel">
-      <section class="balance">
-        <label>Balance</label>
-        <span id="balance-display">--- sats</span>
-      </section>
-
-      <section id="address-section" class="address-section" hidden>
-        <label>Receive Address</label>
-        <div class="address-row">
-          <span id="address-display" class="address-text"></span>
-          <button id="copy-address-btn" class="copy-btn" title="Copy address">Copy</button>
-        </div>
-      </section>
-
-      <section id="identity-section" class="address-section" hidden>
-        <label>Identity Key</label>
-        <div class="address-row">
-          <span id="identity-display" class="address-text"></span>
-          <button id="copy-identity-btn" class="copy-btn" title="Copy identity key">Copy</button>
-        </div>
-      </section>
-
-      <div class="actions">
-        <div id="unlock-form" class="unlock-form" hidden>
-          <input type="password" id="unlock-password" placeholder="Enter password" autocomplete="current-password">
-          <div id="unlock-error" class="unlock-error"></div>
-        </div>
-        <button id="lock-btn" class="btn lock-btn locked">Unlock</button>
-      </div>
-
-      <div id="setup-container" class="setup-container" hidden>
-        <button id="setup-btn" class="btn setup-btn">Set Up Wallet</button>
-      </div>
-    </div>
-
-    <!-- ============================================================
-         x402 panel — autospend controls
-         ============================================================ -->
-    <div id="x402-panel">
-      <section class="tier">
-        <label>Difficulty</label>
-        <select id="tier-select">
-          <option value="I'm Too Young to Die">I'm Too Young to Die</option>
-          <option value="Hey, Not Too Rough">Hey, Not Too Rough</option>
-          <option value="Hurt Me Plenty" selected>Hurt Me Plenty</option>
-          <option value="Ultra-Violence">Ultra-Violence</option>
-          <option value="Nightmare!">Nightmare!</option>
-        </select>
-      </section>
-
-      <section class="weapon">
-        <label>Weapon (per-tx max)</label>
-        <select id="weapon-select">
-          <option value="Fists">Fists (100k sats)</option>
-          <option value="Chainsaw">Chainsaw (250k sats)</option>
-          <option value="Pistol">Pistol (500k sats)</option>
-          <option value="Shotgun" selected>Shotgun (1M sats)</option>
-          <option value="Super Shotgun">Super Shotgun (10M sats)</option>
-          <option value="Chaingun">Chaingun (50M sats)</option>
-          <option value="Rocket Launcher">Rocket Launcher (250M sats)</option>
-          <option value="Plasma Rifle">Plasma Rifle (1B sats)</option>
-          <option value="BFG9000">BFG9000 (no limit)</option>
-        </select>
-      </section>
-
-      <section class="autospend">
-        <label>Autospend Balance</label>
-        <div class="health-bar">
-          <div id="health-bar-fill" class="health-bar-fill"></div>
-        </div>
-        <div class="autospend-text">
-          <span id="autospend-value">-- sats</span>
-          <span id="autospend-cap">/ -- sats</span>
-        </div>
-      </section>
-
-      <section class="pickups">
-        <label>Pickups (recharge autospend)</label>
-        <div class="pickup-buttons">
-          <button class="pickup-btn" data-pickup="Medkit">Medkit +10%</button>
-          <button class="pickup-btn" data-pickup="Stimpak">Stimpak +25%</button>
-          <button class="pickup-btn" data-pickup="Soul Sphere">Soul Sphere +100%</button>
-          <button class="pickup-btn new-game" data-pickup="New Game">New Game</button>
-        </div>
-      </section>
-
-      <section id="send-section" class="address-section">
-        <label>Send</label>
-        <div class="send-form">
-          <input type="text" id="send-address" placeholder="BSV address">
-          <input type="number" id="send-amount" placeholder="Amount (sats)">
-          <button id="send-btn" class="btn send-btn">Send</button>
-          <div id="send-result" class="unlock-error"></div>
-        </div>
-      </section>
-    </div>
-
-    <!-- ============================================================
-         Tools panel — wallet maintenance
-         ============================================================ -->
-    <div id="tools-panel" hidden>
-      <section class="tier">
-        <label>Tools</label>
-        <button id="verify-utxos-btn" class="btn verify-btn">Verify UTXOs</button>
-        <div id="verify-result" class="verify-result"></div>
-        <button id="utxo-admin-btn" class="btn verify-btn" style="margin-top: 6px;">UTXO Admin</button>
-      </section>
-    </div>
-
+  <!-- App shell — hidden until state is fetched (fixes flash-of-locked-state) -->
+  <div id="app" class="popup" hidden>
+    <div id="header"></div>
+    <div id="page-container"></div>
     <footer>
       <span class="footer-text">x402 Wallet <span id="version-info"></span></span>
     </footer>

--- a/plugins/shared/ui/popup.ts
+++ b/plugins/shared/ui/popup.ts
@@ -5,6 +5,9 @@ import type { PopupState } from "./state";
 import { initRouter, registerPages, navigate, getCurrentPage } from "./router";
 import { renderHeader, updateHeader } from "./components/header";
 import * as home from "./pages/home";
+import * as payments from "./pages/payments";
+import * as transactions from "./pages/transactions";
+import * as settings from "./pages/settings";
 
 // Build-time constants injected by tsup --define
 declare const __X402_VERSION__: string;
@@ -34,8 +37,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   registerPages({
     home,
     payments: placeholder,
-    transactions: placeholder,
-    settings: placeholder,
+    transactions,
+    settings,
   });
 
   // Fetch state from service worker (spinner stays visible until this resolves)

--- a/plugins/shared/ui/popup.ts
+++ b/plugins/shared/ui/popup.ts
@@ -3,6 +3,7 @@
 import { fetchState, startPolling } from "./state";
 import type { PopupState } from "./state";
 import { initRouter, registerPages, navigate, getCurrentPage } from "./router";
+import type { Page } from "./router";
 import { renderHeader, updateHeader } from "./components/header";
 import * as home from "./pages/home";
 import * as payments from "./pages/payments";
@@ -60,11 +61,13 @@ document.addEventListener("DOMContentLoaded", async () => {
     versionEl.textContent = `v${__X402_VERSION__} (${__X402_GIT_REF__})`;
   }
 
-  // Poll state to keep the UI fresh
+  // Poll state to keep the UI fresh (incremental update, not full re-render)
   startPolling((newState) => {
     state = newState;
-    // Re-render the active page with updated state
-    navigate(getCurrentPage(), pageContainer, state);
+    const currentPageModule = { home, payments, transactions, settings }[getCurrentPage()] as Page & { update?: (c: HTMLElement, s: PopupState) => void };
+    if (currentPageModule?.update) {
+      currentPageModule.update(pageContainer, state);
+    }
     updateHeader(headerEl, state, getCurrentPage());
   });
 

--- a/plugins/shared/ui/popup.ts
+++ b/plugins/shared/ui/popup.ts
@@ -1,222 +1,65 @@
 /// <reference types="chrome" />
 
-import type { TierName, WeaponName, PickupName } from "../../../src/types";
-
-// ---------------------------------------------------------------------------
-// Popup state — composed from wallet + x402 controllers
-// ---------------------------------------------------------------------------
-
-interface PopupState {
-  // Wallet concerns
-  isSetUp: boolean;
-  isUnlocked: boolean;
-  network: string;
-  balance?: number;
-  // Autospend concerns
-  tier: TierName;
-  weapon: WeaponName;
-  autospendBalance: number;
-  tierCap: number;
-  weaponCap: number;
-}
-
-const $ = <T extends HTMLElement>(id: string): T =>
-  document.getElementById(id) as T;
-
-async function copyToClipboard(text: string, btn: HTMLElement): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch {
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand("copy");
-    document.body.removeChild(textarea);
-  }
-  const original = btn.textContent;
-  btn.textContent = "Copied!";
-  setTimeout(() => { btn.textContent = original; }, 1500);
-}
-
-// ---------------------------------------------------------------------------
-// Wallet panel UI (only when built-in backend is active)
-// ---------------------------------------------------------------------------
-
-function updateWalletPanel(state: PopupState): void {
-  const statusEl = document.getElementById("status-indicator");
-  const balanceEl = document.getElementById("balance-display");
-  const lockBtn = document.getElementById("lock-btn") as HTMLButtonElement | null;
-  const setupContainer = document.getElementById("setup-container") as HTMLDivElement | null;
-
-  // Wallet panel elements may not exist if wallet UI has been removed
-  if (!statusEl || !balanceEl || !lockBtn || !setupContainer) return;
-
-  if (!state.isSetUp) {
-    setupContainer.hidden = false;
-    lockBtn.style.display = "none";
-    return;
-  }
-
-  setupContainer.hidden = true;
-  lockBtn.style.display = "";
-
-  const unlockForm = document.getElementById("unlock-form") as HTMLDivElement | null;
-  const unlockPassword = document.getElementById("unlock-password") as HTMLInputElement | null;
-  const unlockError = document.getElementById("unlock-error") as HTMLDivElement | null;
-
-  if (state.isUnlocked) {
-    statusEl.textContent = "Unlocked";
-    statusEl.className = "status unlocked";
-    lockBtn.textContent = "Lock";
-    lockBtn.className = "btn lock-btn unlocked";
-    if (unlockForm) unlockForm.hidden = true;
-  } else {
-    statusEl.textContent = "Locked";
-    statusEl.className = "status locked";
-    lockBtn.textContent = "Unlock";
-    lockBtn.className = "btn lock-btn locked";
-    // Show password form automatically when locked
-    if (unlockForm && unlockPassword) {
-      unlockForm.hidden = false;
-      if (unlockError) unlockError.textContent = "";
-      if (!unlockPassword.value) unlockPassword.focus();
-    }
-  }
-
-  balanceEl.textContent =
-    state.balance !== undefined ? `${state.balance.toLocaleString()} sats` : "--- sats";
-
-  // Show/hide address and identity sections based on unlock state
-  const addressSection = document.getElementById("address-section") as HTMLDivElement | null;
-  const identitySection = document.getElementById("identity-section") as HTMLDivElement | null;
-  if (addressSection) addressSection.hidden = !state.isUnlocked;
-  if (identitySection) identitySection.hidden = !state.isUnlocked;
-}
-
-// ---------------------------------------------------------------------------
-// x402 panel UI (always shown)
-// ---------------------------------------------------------------------------
-
-function updateX402Panel(state: PopupState): void {
-  const tierSelect = document.getElementById("tier-select") as HTMLSelectElement | null;
-  const weaponSelect = document.getElementById("weapon-select") as HTMLSelectElement | null;
-  const healthFill = document.getElementById("health-bar-fill") as HTMLDivElement | null;
-  const autospendValue = document.getElementById("autospend-value") as HTMLSpanElement | null;
-  const autospendCap = document.getElementById("autospend-cap") as HTMLSpanElement | null;
-
-  if (tierSelect) tierSelect.value = state.tier;
-  if (weaponSelect) weaponSelect.value = state.weapon;
-
-  // Health bar: percentage of tier cap
-  if (healthFill && state.tierCap > 0) {
-    const pct = Math.max(0, Math.min(100, (state.autospendBalance / state.tierCap) * 100));
-    healthFill.style.width = `${pct}%`;
-    healthFill.classList.remove("low", "critical");
-    if (pct < 25) healthFill.classList.add("critical");
-    else if (pct < 50) healthFill.classList.add("low");
-  }
-
-  if (autospendValue) {
-    autospendValue.textContent = `${state.autospendBalance.toLocaleString()} sats`;
-  }
-  if (autospendCap) {
-    autospendCap.textContent = `/ ${state.tierCap.toLocaleString()} sats`;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Message helper
-// ---------------------------------------------------------------------------
-
-function sendMessage(msg: Record<string, unknown>): Promise<PopupState> {
-  return new Promise<PopupState>((resolve, reject) => {
-    chrome.runtime.sendMessage(msg, (response) => {
-      if (chrome.runtime.lastError) {
-        reject(new Error(chrome.runtime.lastError.message));
-        return;
-      }
-      if (response?.status === 'error') {
-        reject(new Error(response.error ?? 'Unknown error'));
-        return;
-      }
-      resolve(response as PopupState);
-    });
-  });
-}
+import { fetchState, startPolling } from "./state";
+import type { PopupState } from "./state";
+import { initRouter, registerPages, navigate, getCurrentPage } from "./router";
+import { renderHeader, updateHeader } from "./components/header";
+import * as home from "./pages/home";
 
 // Build-time constants injected by tsup --define
 declare const __X402_VERSION__: string;
 declare const __X402_GIT_REF__: string;
 
 // ---------------------------------------------------------------------------
+// Placeholder page for tabs not yet implemented
+// ---------------------------------------------------------------------------
+
+const placeholder = {
+  render(container: HTMLElement, _state: PopupState): void {
+    container.innerHTML = `<p class="placeholder">Coming soon</p>`;
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Initialisation
 // ---------------------------------------------------------------------------
 
 document.addEventListener("DOMContentLoaded", async () => {
-  const walletPanel = document.getElementById("wallet-panel");
+  const loadingEl = document.getElementById("loading")!;
+  const appEl = document.getElementById("app")!;
+  const headerEl = document.getElementById("header")!;
+  const pageContainer = document.getElementById("page-container")!;
 
-  // Check if wallet backend has its own UI — hide wallet panel if so
-  if (walletPanel) {
-    try {
-      const result = await chrome.storage.local.get("x402_wallet_backend");
-      const backendConfig = result.x402_wallet_backend as { type: string } | undefined;
-      if (backendConfig?.type === "external") {
-        walletPanel.style.display = "none";
-      }
-    } catch {
-      // Default: show wallet panel
-    }
-  }
+  // Register page modules — only Home is implemented; others are placeholders
+  registerPages({
+    home,
+    payments: placeholder,
+    transactions: placeholder,
+    settings: placeholder,
+  });
 
-  // Fetch and display wallet identity key + address when unlocked
-  async function fetchWalletInfo(): Promise<void> {
-    const addressDisplay = document.getElementById("address-display");
-    const identityDisplay = document.getElementById("identity-display");
-    const identitySection = document.getElementById("identity-section");
-    try {
-      const result = await sendMessage({ type: "getAddress" }) as PopupState & { identityKey?: string; address?: string };
-      if (identityDisplay && result.identityKey) {
-        identityDisplay.textContent = result.identityKey;
-        if (identitySection) identitySection.hidden = false;
-      }
-      if (addressDisplay && result.address) {
-        addressDisplay.textContent = result.address;
-      }
-    } catch {
-      if (addressDisplay) addressDisplay.textContent = "";
-      if (identityDisplay) identityDisplay.textContent = "";
-    }
-  }
+  // Fetch state from service worker (spinner stays visible until this resolves)
+  let state = await fetchState();
 
-  // Fetch initial state
-  function updateUI(state: PopupState): void {
-    updateWalletPanel(state);
-    updateX402Panel(state);
+  // Swap spinner for app content
+  loadingEl.hidden = true;
+  appEl.hidden = false;
 
-    // Hide x402 and tools panels when wallet is locked
-    const x402Panel = document.getElementById("x402-panel");
-    const toolsPanel = document.getElementById("tools-panel");
-    if (x402Panel) x402Panel.hidden = !state.isUnlocked;
-    if (toolsPanel) toolsPanel.hidden = !state.isUnlocked;
-  }
+  // Render header with tab navigation
+  const currentPage = getCurrentPage();
+  renderHeader(headerEl, state, currentPage, (page) => {
+    navigate(page, pageContainer, state);
+    updateHeader(headerEl, state, getCurrentPage());
+  });
 
-  try {
-    const state = await sendMessage({ type: "getState" });
-    updateUI(state);
-    if (state.isUnlocked) fetchWalletInfo();
-  } catch {
-    updateUI({
-      isSetUp: false,
-      isUnlocked: false,
-      network: "mainnet",
-      tier: "Hurt Me Plenty",
-      weapon: "Shotgun",
-      autospendBalance: 0,
-      tierCap: 100_000_000,
-      weaponCap: 1_000_000,
-    });
-  }
+  // Initialise router (listens for hashchange)
+  initRouter({
+    container: pageContainer,
+    onNavigated: (page) => updateHeader(headerEl, state, page),
+  });
+
+  // Navigate to the current hash (or default to home)
+  navigate(currentPage, pageContainer, state);
 
   // Display version + git ref in footer
   const versionEl = document.getElementById("version-info");
@@ -224,231 +67,32 @@ document.addEventListener("DOMContentLoaded", async () => {
     versionEl.textContent = `v${__X402_VERSION__} (${__X402_GIT_REF__})`;
   }
 
-  // Poll balance every 10s while popup is open
-  setInterval(async () => {
-    try {
-      const state = await sendMessage({ type: "getState" });
-      updateUI(state);
-    } catch {
-      // Ignore — background may be restarting
-    }
-  }, 10_000);
-
-  // Wallet: Lock / Unlock (guarded — wallet panel may not exist)
-  const lockBtn = document.getElementById("lock-btn") as HTMLButtonElement | null;
-
-  if (lockBtn) {
-    lockBtn.addEventListener("click", async () => {
-      const statusEl = document.getElementById("status-indicator");
-      if (!statusEl) return;
-      const isCurrentlyUnlocked = statusEl.classList.contains("unlocked");
-
-      if (isCurrentlyUnlocked) {
-        const state = await sendMessage({ type: "lock" });
-        updateUI(state);
-      } else {
-        // Submit password
-        const unlockPassword = document.getElementById("unlock-password") as HTMLInputElement | null;
-        const unlockError = document.getElementById("unlock-error") as HTMLDivElement | null;
-        if (unlockPassword) {
-          const password = unlockPassword.value;
-          if (!password) {
-            unlockPassword.focus();
-            return;
-          }
-
-          lockBtn.disabled = true;
-          try {
-            const state = await sendMessage({ type: "unlock", payload: { password } });
-            unlockPassword.value = "";
-            updateUI(state);
-            fetchWalletInfo();
-          } catch (err) {
-            if (unlockError) unlockError.textContent = err instanceof Error ? err.message : String(err);
-          } finally {
-            lockBtn.disabled = false;
-          }
-        }
-      }
-    });
-
-    // Allow Enter key to submit password
-    const passwordInput = document.getElementById("unlock-password") as HTMLInputElement | null;
-    if (passwordInput) {
-      passwordInput.addEventListener("keydown", (e) => {
-        if (e.key === "Enter") lockBtn.click();
-      });
-    }
-  }
-
-  // x402: Indicator mode — load/save (hidden until #115 is implemented)
-  const indicatorSelect = document.getElementById("indicator-mode-select") as HTMLSelectElement | null;
-  if (indicatorSelect) {
-    chrome.storage.local.get("x402_indicator_mode", (result) => {
-      const mode = result.x402_indicator_mode as string | undefined;
-      if (mode) indicatorSelect.value = mode;
-    });
-    indicatorSelect.addEventListener("change", () => {
-      chrome.storage.local.set({ x402_indicator_mode: indicatorSelect.value });
-    });
-  }
-
-  // x402: Tier change
-  $<HTMLSelectElement>("tier-select").addEventListener("change", async (e) => {
-    const tier = (e.target as HTMLSelectElement).value as TierName;
-    try {
-      const state = await sendMessage({ type: "setTier", payload: { tier } });
-      updateUI(state);
-    } catch (err) {
-      alert(`Tier change failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
+  // Poll state to keep the UI fresh
+  startPolling((newState) => {
+    state = newState;
+    // Re-render the active page with updated state
+    navigate(getCurrentPage(), pageContainer, state);
+    updateHeader(headerEl, state, getCurrentPage());
   });
 
-  // x402: Weapon change
-  $<HTMLSelectElement>("weapon-select").addEventListener("change", async (e) => {
-    const weapon = (e.target as HTMLSelectElement).value as WeaponName;
-    try {
-      const state = await sendMessage({ type: "setWeapon", payload: { weapon } });
-      updateUI(state);
-    } catch (err) {
-      alert(`Weapon change failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  });
-
-  // x402: Pickup buttons
-  document.querySelectorAll<HTMLButtonElement>(".pickup-btn").forEach((btn) => {
-    btn.addEventListener("click", async () => {
-      const pickup = btn.dataset.pickup as PickupName | undefined;
-      if (!pickup) return;
-      try {
-        const state = await sendMessage({ type: "pickup", payload: { pickup } });
-        updateUI(state);
-      } catch (err) {
-        alert(`Pickup failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
+  // Listen for state changes from header lock/unlock button
+  window.addEventListener("x402-state-changed", ((e: CustomEvent<PopupState>) => {
+    state = e.detail;
+    renderHeader(headerEl, state, getCurrentPage(), (page) => {
+      navigate(page, pageContainer, state);
+      updateHeader(headerEl, state, getCurrentPage());
     });
-  });
-
-  // Wallet: Set up (guarded — wallet panel may not exist)
-  const setupBtn = document.getElementById("setup-btn");
-  if (setupBtn) {
-    setupBtn.addEventListener("click", () => {
-      chrome.tabs.create({ url: chrome.runtime.getURL("ui/wallet/setup.html") });
-    });
-  }
-
-  // Wallet: Copy identity key
-  const copyIdentityBtn = document.getElementById("copy-identity-btn");
-  if (copyIdentityBtn) {
-    copyIdentityBtn.addEventListener("click", async () => {
-      const identityDisplay = document.getElementById("identity-display");
-      const text = identityDisplay?.textContent ?? "";
-      if (!text) return;
-      await copyToClipboard(text, copyIdentityBtn);
-    });
-  }
-
-  // Wallet: Copy address
-  const copyAddressBtn = document.getElementById("copy-address-btn");
-  if (copyAddressBtn) {
-    copyAddressBtn.addEventListener("click", async () => {
-      const text = document.getElementById("address-display")?.textContent ?? "";
-      if (text) await copyToClipboard(text, copyAddressBtn);
-    });
-  }
-
-  // Wallet: Verify UTXOs (janitor)
-  const verifyUtxosBtn = document.getElementById("verify-utxos-btn") as HTMLButtonElement | null;
-  if (verifyUtxosBtn) {
-    verifyUtxosBtn.addEventListener("click", async () => {
-      const resultEl = document.getElementById("verify-result") as HTMLDivElement;
-      verifyUtxosBtn.disabled = true;
-      verifyUtxosBtn.textContent = "Verifying...";
-      resultEl.textContent = "";
-      try {
-        const state = await sendMessage({ type: "verifyUtxos" });
-        const vr = (state as any).verifyResult as
-          | { checked: number; relinquished: number; failed: number }
-          | undefined;
-
-        resultEl.className = "verify-result";
-
-        if (!vr || vr.checked === 0) {
-          resultEl.textContent = "No outputs to verify";
-          resultEl.classList.add("verify-success");
-        } else if (vr.relinquished === 0 && vr.failed === 0) {
-          resultEl.textContent = `Checked ${vr.checked} output${vr.checked !== 1 ? "s" : ""}: all valid`;
-          resultEl.classList.add("verify-success");
-        } else {
-          const parts: string[] = [`Checked ${vr.checked}`];
-          if (vr.relinquished > 0) {
-            parts.push(`released ${vr.relinquished} spent output${vr.relinquished !== 1 ? "s" : ""}`);
-          }
-          if (vr.failed > 0) {
-            parts.push(`${vr.failed} lookup failure${vr.failed !== 1 ? "s" : ""}`);
-          }
-          resultEl.textContent = parts.join(", ");
-          resultEl.classList.add(vr.failed > 0 ? "verify-error" : "verify-warning");
-        }
-        updateUI(state);
-      } catch (err) {
-        resultEl.className = "verify-result verify-error";
-        resultEl.textContent = err instanceof Error ? err.message : String(err);
-      } finally {
-        verifyUtxosBtn.disabled = false;
-        verifyUtxosBtn.textContent = "Verify UTXOs";
-      }
-    });
-  }
-
-  // Wallet: UTXO Admin — open in a tab
-  const utxoAdminBtn = document.getElementById("utxo-admin-btn") as HTMLButtonElement | null;
-  if (utxoAdminBtn) {
-    utxoAdminBtn.addEventListener("click", () => {
-      chrome.tabs.create({ url: chrome.runtime.getURL("ui/admin/utxos.html") });
-    });
-  }
-
-  // Wallet: Send funds
-  const sendBtn = document.getElementById("send-btn") as HTMLButtonElement | null;
-  if (sendBtn) {
-    sendBtn.addEventListener("click", async () => {
-      const addressInput = document.getElementById("send-address") as HTMLInputElement;
-      const amountInput = document.getElementById("send-amount") as HTMLInputElement;
-      const resultEl = document.getElementById("send-result") as HTMLDivElement;
-
-      const address = addressInput.value.trim();
-      const amount = parseInt(amountInput.value, 10);
-
-      if (!address) { resultEl.textContent = "Enter an address"; return; }
-      if (!amount || amount <= 0) { resultEl.textContent = "Enter a valid amount"; return; }
-
-      sendBtn.disabled = true;
-      resultEl.textContent = "Sending...";
-      resultEl.style.color = "";
-
-      try {
-        const state = await sendMessage({ type: "sendFunds", payload: { address, amount } });
-        const txid = (state as any).sendTxid as string;
-        resultEl.textContent = `Sent! txid: ${txid.slice(0, 12)}...`;
-        resultEl.style.color = "#00d4aa";
-        addressInput.value = "";
-        amountInput.value = "";
-        updateUI(state);
-      } catch (err) {
-        resultEl.textContent = err instanceof Error ? err.message : String(err);
-        resultEl.style.color = "#e74c3c";
-      } finally {
-        sendBtn.disabled = false;
-      }
-    });
-  }
+    navigate(getCurrentPage(), pageContainer, state);
+  }) as EventListener);
 
   // Listen for balance updates from background (e.g. after UTXO import)
   chrome.runtime.onMessage.addListener((message) => {
-    if (message?.type === 'balanceUpdated') {
-      sendMessage({ type: "getState" }).then(updateUI).catch(() => {});
+    if (message?.type === "balanceUpdated") {
+      fetchState().then((newState) => {
+        state = newState;
+        navigate(getCurrentPage(), pageContainer, state);
+        updateHeader(headerEl, state, getCurrentPage());
+      }).catch(() => {});
     }
   });
-
 });

--- a/plugins/shared/ui/popup.ts
+++ b/plugins/shared/ui/popup.ts
@@ -14,16 +14,6 @@ declare const __X402_VERSION__: string;
 declare const __X402_GIT_REF__: string;
 
 // ---------------------------------------------------------------------------
-// Placeholder page for tabs not yet implemented
-// ---------------------------------------------------------------------------
-
-const placeholder = {
-  render(container: HTMLElement, _state: PopupState): void {
-    container.innerHTML = `<p class="placeholder">Coming soon</p>`;
-  },
-};
-
-// ---------------------------------------------------------------------------
 // Initialisation
 // ---------------------------------------------------------------------------
 
@@ -33,10 +23,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   const headerEl = document.getElementById("header")!;
   const pageContainer = document.getElementById("page-container")!;
 
-  // Register page modules — only Home is implemented; others are placeholders
+  // Register page modules
   registerPages({
     home,
-    payments: placeholder,
+    payments,
     transactions,
     settings,
   });

--- a/plugins/shared/ui/router.ts
+++ b/plugins/shared/ui/router.ts
@@ -1,0 +1,199 @@
+/// <reference types="chrome" />
+
+import type { PopupState } from "./state";
+import { sendMessage } from "./state";
+
+// ---------------------------------------------------------------------------
+// Page interface — each page module implements this
+// ---------------------------------------------------------------------------
+
+export interface Page {
+  render(container: HTMLElement, state: PopupState): void;
+}
+
+// ---------------------------------------------------------------------------
+// Valid page names
+// ---------------------------------------------------------------------------
+
+const VALID_PAGES = ["home", "payments", "transactions", "settings"] as const;
+export type PageName = (typeof VALID_PAGES)[number];
+
+function isValidPage(page: string): page is PageName {
+  return (VALID_PAGES as readonly string[]).includes(page);
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const pages: Partial<Record<PageName, Page>> = {};
+
+/** Register page modules the router can navigate to. */
+export function registerPages(entries: Partial<Record<PageName, Page>>): void {
+  Object.assign(pages, entries);
+}
+
+// ---------------------------------------------------------------------------
+// Lock screen
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the lock/unlock form. When the wallet is locked the router shows
+ * this instead of any page content. On successful unlock the supplied
+ * `onUnlock` callback re-renders the active page.
+ */
+function renderLockScreen(
+  container: HTMLElement,
+  state: PopupState,
+  onUnlock: (state: PopupState) => void,
+): void {
+  // If the wallet has not been set up yet, show the setup prompt
+  if (!state.isSetUp) {
+    container.innerHTML = `
+      <div class="lock-screen">
+        <p class="lock-title">Wallet not set up</p>
+        <button class="btn setup-btn" id="lock-setup-btn">Set Up Wallet</button>
+      </div>
+    `;
+    const setupBtn = container.querySelector("#lock-setup-btn") as HTMLButtonElement;
+    setupBtn.addEventListener("click", () => {
+      chrome.tabs.create({ url: chrome.runtime.getURL("ui/wallet/setup.html") });
+    });
+    return;
+  }
+
+  container.innerHTML = `
+    <div class="lock-screen">
+      <p class="lock-title">Wallet is locked</p>
+      <div class="lock-form">
+        <input
+          type="password"
+          id="lock-password"
+          class="input"
+          placeholder="Password"
+          autocomplete="current-password"
+        />
+        <div id="lock-error" class="lock-error"></div>
+        <button class="btn unlock-btn" id="lock-unlock-btn">Unlock</button>
+      </div>
+    </div>
+  `;
+
+  const passwordInput = container.querySelector("#lock-password") as HTMLInputElement;
+  const unlockBtn = container.querySelector("#lock-unlock-btn") as HTMLButtonElement;
+  const errorEl = container.querySelector("#lock-error") as HTMLDivElement;
+
+  passwordInput.focus();
+
+  async function attemptUnlock(): Promise<void> {
+    const password = passwordInput.value;
+    if (!password) {
+      passwordInput.focus();
+      return;
+    }
+
+    unlockBtn.disabled = true;
+    errorEl.textContent = "";
+
+    try {
+      const newState = await sendMessage<PopupState>("unlock", { password });
+      passwordInput.value = "";
+      onUnlock(newState);
+    } catch (err) {
+      errorEl.textContent = err instanceof Error ? err.message : String(err);
+    } finally {
+      unlockBtn.disabled = false;
+    }
+  }
+
+  unlockBtn.addEventListener("click", attemptUnlock);
+  passwordInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") attemptUnlock();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+/** The container element that pages render into — set by `initRouter`. */
+let pageContainer: HTMLElement | null = null;
+
+/** Callback invoked after navigation so the header can update. */
+let onNavigated: ((page: PageName) => void) | null = null;
+
+/**
+ * Read the current page from `location.hash`, defaulting to `home`
+ * for empty or invalid hashes.
+ */
+export function getCurrentPage(): PageName {
+  const raw = location.hash.replace(/^#/, "");
+  return isValidPage(raw) ? raw : "home";
+}
+
+/**
+ * Navigate to a page. Sets `location.hash` and renders the page into the
+ * container. If the wallet is locked the lock screen is shown instead,
+ * preserving the hash so that unlocking returns to the intended page.
+ */
+export function navigate(page: string, container: HTMLElement, state: PopupState): void {
+  const target = isValidPage(page) ? page : "home";
+
+  // Update hash without triggering our own hashchange listener
+  if (location.hash !== `#${target}`) {
+    location.hash = target;
+  }
+
+  // Lock screen intercept
+  if (!state.isUnlocked) {
+    renderLockScreen(container, state, (newState) => {
+      // Re-navigate after unlock — the page will now render
+      navigate(getCurrentPage(), container, newState);
+    });
+    onNavigated?.(target);
+    return;
+  }
+
+  // Render the requested page (or nothing if not yet registered)
+  const pageModule = pages[target];
+  if (pageModule) {
+    pageModule.render(container, state);
+  } else {
+    container.innerHTML = `<p class="placeholder">Coming soon</p>`;
+  }
+
+  onNavigated?.(target);
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation
+// ---------------------------------------------------------------------------
+
+export interface RouterOptions {
+  /** The element that page content renders into. */
+  container: HTMLElement;
+  /** Called after each navigation with the new active page name. */
+  onNavigated?: (page: PageName) => void;
+}
+
+/**
+ * Initialise the router. Listens for `hashchange` events and re-renders
+ * when the hash changes. Call `navigate()` after this to render the
+ * initial page.
+ */
+export function initRouter(opts: RouterOptions): void {
+  pageContainer = opts.container;
+  onNavigated = opts.onNavigated ?? null;
+
+  window.addEventListener("hashchange", () => {
+    if (!pageContainer) return;
+    // State is not available synchronously here — fetch it and re-render.
+    // The caller should set up polling; this handler covers manual hash
+    // changes (e.g. user editing the URL bar or back/forward navigation).
+    import("./state").then(({ fetchState }) => {
+      fetchState().then((state) => {
+        navigate(getCurrentPage(), pageContainer!, state);
+      });
+    });
+  });
+}

--- a/plugins/shared/ui/router.ts
+++ b/plugins/shared/ui/router.ts
@@ -18,6 +18,9 @@ export interface Page {
 const VALID_PAGES = ["home", "payments", "transactions", "settings"] as const;
 export type PageName = (typeof VALID_PAGES)[number];
 
+/** Pages that require an unlocked wallet. */
+const REQUIRES_UNLOCK: ReadonlySet<string> = new Set(["payments", "transactions"]);
+
 function isValidPage(page: string): page is PageName {
   return (VALID_PAGES as readonly string[]).includes(page);
 }
@@ -98,7 +101,10 @@ function renderLockScreen(
     try {
       const newState = await sendMessage<PopupState>("unlock", { password });
       passwordInput.value = "";
-      onUnlock(newState);
+      // Notify popup.ts so it updates its state and re-renders the header
+      window.dispatchEvent(
+        new CustomEvent("x402-state-changed", { detail: newState }),
+      );
     } catch (err) {
       errorEl.textContent = err instanceof Error ? err.message : String(err);
     } finally {
@@ -144,8 +150,9 @@ export function navigate(page: string, container: HTMLElement, state: PopupState
     location.hash = target;
   }
 
-  // Lock screen intercept
-  if (!state.isUnlocked) {
+  // Lock screen intercept — only for pages that require unlock, or home
+  // (Settings stays accessible when locked for recovery purposes)
+  if (!state.isUnlocked && (target === "home" || REQUIRES_UNLOCK.has(target))) {
     renderLockScreen(container, state, (newState) => {
       // Re-navigate after unlock — the page will now render
       navigate(getCurrentPage(), container, newState);

--- a/plugins/shared/ui/state.ts
+++ b/plugins/shared/ui/state.ts
@@ -1,0 +1,137 @@
+/// <reference types="chrome" />
+
+import type { TierName, WeaponName } from "../../../src/types";
+
+// ---------------------------------------------------------------------------
+// PopupState — all state the popup needs from the service worker
+// ---------------------------------------------------------------------------
+
+export interface PopupState {
+  // Wallet concerns
+  isSetUp: boolean;
+  isUnlocked: boolean;
+  network: string;
+  balance?: number;
+  // Autospend concerns
+  tier: TierName;
+  weapon: WeaponName;
+  autospendBalance: number;
+  tierCap: number;
+  weaponCap: number;
+}
+
+/** Default state returned when the service worker is unreachable. */
+const DEFAULT_STATE: PopupState = {
+  isSetUp: false,
+  isUnlocked: false,
+  network: "mainnet",
+  tier: "Hurt Me Plenty",
+  weapon: "Shotgun",
+  autospendBalance: 0,
+  tierCap: 100_000_000,
+  weaponCap: 1_000_000,
+};
+
+// ---------------------------------------------------------------------------
+// Message helper — typed wrapper around chrome.runtime.sendMessage
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a message to the background service worker and return the typed
+ * response. Rejects on `chrome.runtime.lastError` or if the response
+ * has `status: 'error'`.
+ */
+export function sendMessage<T = PopupState>(
+  type: string,
+  payload?: Record<string, unknown>,
+): Promise<T> {
+  const msg: Record<string, unknown> = { type };
+  if (payload !== undefined) msg.payload = payload;
+
+  return new Promise<T>((resolve, reject) => {
+    chrome.runtime.sendMessage(msg, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      if (response?.status === "error") {
+        reject(new Error(response.error ?? "Unknown error"));
+        return;
+      }
+      resolve(response as T);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// State fetching
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the full popup state from the service worker via `getState`.
+ * Returns a sensible default on failure (e.g. service worker cold start).
+ */
+export async function fetchState(): Promise<PopupState> {
+  try {
+    return await sendMessage<PopupState>("getState");
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Polling
+// ---------------------------------------------------------------------------
+
+/**
+ * Poll `fetchState()` on an interval and invoke `callback` with the
+ * latest state. Returns a cleanup function that stops the polling.
+ *
+ * @param callback - called with new state on each successful poll
+ * @param intervalMs - polling interval in milliseconds (default 10 000)
+ */
+export function startPolling(
+  callback: (state: PopupState) => void,
+  intervalMs = 10_000,
+): () => void {
+  const id = setInterval(async () => {
+    try {
+      const state = await sendMessage<PopupState>("getState");
+      callback(state);
+    } catch {
+      // Ignore — service worker may be restarting
+    }
+  }, intervalMs);
+
+  return () => clearInterval(id);
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Copy text to the clipboard, falling back to `document.execCommand`
+ * for older browsers that lack `navigator.clipboard`. Briefly changes
+ * the button label to "Copied!" as visual feedback.
+ */
+export async function copyToClipboard(
+  text: string,
+  btn: HTMLElement,
+): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+  }
+  const original = btn.textContent;
+  btn.textContent = "Copied!";
+  setTimeout(() => {
+    btn.textContent = original;
+  }, 1500);
+}

--- a/plugins/shared/verify-utxos.test.ts
+++ b/plugins/shared/verify-utxos.test.ts
@@ -23,7 +23,7 @@ const TX2 = 'ccdd'.repeat(16)
 const TX3 = 'eeff'.repeat(16)
 
 /** Skip inter-request delay in tests */
-const opts = { delayMs: 0, backoffMs: 0 }
+const opts = { delayMs: 0, initialBackoffMs: 0, maxRetries: 1 }
 
 describe('verifyUtxos', () => {
   let backend: WalletBackend
@@ -151,13 +151,16 @@ describe('verifyUtxos', () => {
       .mockResolvedValueOnce(false) // output 0: unspent
       .mockRejectedValueOnce(new checkModule.WocRateLimitError()) // output 1: rate-limited
       .mockRejectedValueOnce(new checkModule.WocRateLimitError()) // output 1 retry: still limited
+      .mockResolvedValueOnce(false) // output 2: unspent (continues after skip)
+      .mockResolvedValueOnce(false) // output 3: unspent
+      .mockResolvedValueOnce(false) // output 4: unspent
 
     const result = await verifyUtxos(backend, 'main', opts)
 
-    // Checked output 0, then rate-limited twice on output 1 — stops
-    expect(result.checked).toBe(1)
-    expect(result.failed).toBe(0)
-    expect(checkOutpointSpent).toHaveBeenCalledTimes(3)
+    // Output 0 checked, output 1 failed after retries, outputs 2-4 checked
+    expect(result.checked).toBe(4)
+    expect(result.failed).toBe(1)
+    expect(checkOutpointSpent).toHaveBeenCalledTimes(6) // 1 + 2 (1 retry fail) + 3
   })
 
   it('passes correct network to checkOutpointSpent', async () => {

--- a/plugins/shared/verify-utxos.ts
+++ b/plugins/shared/verify-utxos.ts
@@ -17,7 +17,7 @@ export interface VerifyResult {
 export async function verifyUtxos(
   backend: WalletBackend,
   network: WocNetwork,
-  { delayMs = 500, backoffMs = 2000 } = {},
+  { delayMs = 500, initialBackoffMs = 2000, maxRetries = 4 } = {},
 ): Promise<VerifyResult> {
   const result: VerifyResult = { checked: 0, relinquished: 0, failed: 0 }
 
@@ -31,7 +31,7 @@ export async function verifyUtxos(
   console.log(`[x402] verifyUtxos: ${outputs.length} outputs, ${spendable.length} spendable, network=${network}`)
   if (spendable.length === 0) return result
 
-  // Sequential verification with delay — WoC free tier limits to ~3 req/s
+  let currentBackoff = initialBackoffMs
 
   for (const output of spendable) {
     const dotIdx = output.outpoint.lastIndexOf('.')
@@ -40,46 +40,41 @@ export async function verifyUtxos(
     const vout = parseInt(output.outpoint.slice(dotIdx + 1), 10)
     if (isNaN(vout)) { result.failed++; continue }
 
-    try {
-      const spent = await checkOutpointSpent(txid, vout, network)
-      result.checked++
-      if (spent) {
-        try {
-          await backend.call('relinquishOutput', {
-            basket: 'default',
-            output: output.outpoint,
-          }, 'self')
-          result.relinquished++
-        } catch {
-          result.failed++
-        }
-      }
-    } catch (err) {
-      if (err instanceof WocRateLimitError) {
-        // Back off and retry once after 2s
-        console.warn(`[x402] verifyUtxos: rate-limited, backing off ${backoffMs}ms`)
-        if (backoffMs > 0) await new Promise((r) => setTimeout(r, backoffMs))
-        try {
-          const spent = await checkOutpointSpent(txid, vout, network)
-          result.checked++
-          if (spent) {
-            try {
-              await backend.call('relinquishOutput', {
-                basket: 'default',
-                output: output.outpoint,
-              }, 'self')
-              result.relinquished++
-            } catch {
-              result.failed++
-            }
+    // Retry loop with exponential backoff on rate limits
+    let checked = false
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const spent = await checkOutpointSpent(txid, vout, network)
+        result.checked++
+        checked = true
+        if (spent) {
+          try {
+            await backend.call('relinquishOutput', {
+              basket: 'default',
+              output: output.outpoint,
+            }, 'self')
+            result.relinquished++
+          } catch {
+            result.failed++
           }
-        } catch (retryErr) {
-          console.warn(`[x402] verifyUtxos: retry failed, stopping`, retryErr)
+        }
+        // Reset backoff on success
+        currentBackoff = initialBackoffMs
+        break
+      } catch (err) {
+        if (err instanceof WocRateLimitError && attempt < maxRetries) {
+          console.warn(`[x402] verifyUtxos: rate-limited, backing off ${currentBackoff}ms (attempt ${attempt + 1}/${maxRetries})`)
+          await new Promise((r) => setTimeout(r, currentBackoff))
+          currentBackoff = Math.min(currentBackoff * 2, 30_000)
+        } else if (err instanceof WocRateLimitError) {
+          console.warn(`[x402] verifyUtxos: rate limit persists after ${maxRetries} retries, skipping output`)
+          result.failed++
+          break
+        } else {
+          console.warn(`[x402] verifyUtxos lookup failed:`, err)
+          result.failed++
           break
         }
-      } else {
-        console.warn(`[x402] verifyUtxos lookup failed:`, err)
-        result.failed++
       }
     }
 


### PR DESCRIPTION
## Summary

- Restructured popup from monolithic 454-line script to multi-page app with hash-based routing
- Fixed flash-of-locked-state bug (spinner until service worker responds)
- **Home**: balance, autospend health bar, pickup buttons
- **Payments**: send form + receive QR code with identity/address toggle
- **Transactions**: paginated list (20/page) with amount colouring, status badges, WoC links
- **Settings**: difficulty tier, weapon, tools (verify UTXOs, UTXO admin), wallet recovery
- **Recovery**: seed preview (masked), JSON wallet export/import
- Added `listTransactions`, `adminExportWallet`, `adminImportWallet`, `getRootKeyPreview` background handlers
- Added `qr-creator` dependency for QR code rendering

**Note:** Recovery uses JSON export/import (not SQLite as originally planned in HLR) — avoids the ~1MB `sql.js` dependency while achieving the same round-trip capability.

## Acceptance criteria verification

- [x] Multi-page navigation via header tabs (Home, Payments, Transactions, Settings)
- [x] No flash-of-locked-state on popup open (`#app hidden` until `fetchState()` resolves)
- [x] Lock screen shown on all pages when wallet is locked (router intercept)
- [x] Home: balance, autospend, pickups (existing functionality preserved)
- [x] Payments: send form + receive QR + identity/address toggles
- [x] Transactions: paginated list with amount, status, description, WoC link
- [x] Settings: tier, weapon, tools, recovery section
- [x] Recovery: seed preview, JSON export, JSON import with confirmation dialog
- [x] All existing functionality preserved (unlock, lock, send, tier, weapon, pickups, verify, admin)
- [x] Single IIFE bundle per platform (no build changes needed)
- [x] `npm run build:all` succeeds (53.72 KB popup bundle per platform)
- [x] `npm test` passes (311 tests, 10 files)

## Sub-issues

- #161 State module + message helpers (369c5e9)
- #162 Router + header component (689a6c4)
- #163 Home page + health bar component (8dcb75d)
- #164 Shell rewrite — popup.ts + popup.html + popup.css (c75ce6c)
- #165 Settings page (e351567)
- #166 Payments page + QR component (62bff58)
- #167 Transactions page + background handler (5759e6c)
- #168 Recovery — seed preview + export/import (ceee33a)

## Test plan

- [ ] `npm run build:all` succeeds (all 3 browser platforms)
- [ ] `npm test` passes (311 tests)
- [ ] Extension loads in Chrome and popup opens
- [ ] All 4 tabs navigate correctly
- [ ] No flash of locked state on popup open
- [ ] Lock screen appears on all tabs when locked
- [ ] Home: balance, health bar, pickups functional
- [ ] Payments: send form works, receive shows QR + copy
- [ ] Transactions: list populates, pager works, WoC links open
- [ ] Settings: tier/weapon dropdowns, verify UTXOs, UTXO admin
- [ ] Recovery: seed preview shows masked key, export downloads JSON, import restores

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
